### PR TITLE
refactor: improve nav element semantics

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -18,22 +18,27 @@ interface SidebarNavProps extends JSX.HTMLAttributes<HTMLElement> {
 
 function SidebarNav(props: SidebarNavProps) {
   return (
-    <nav class="w-full md:w-[16rem] md:flex-shrink-0 flex flex-col justify-start">
-      {props.items.map((item) => (
-        <a
-          href={item.href}
-          class={`px-4 py-2 rounded w-full ${
-            item.href === props.active
-              ? "bg-gray-100 font-bold"
-              : "hover:bg-gray-100"
-          }`}
-        >
-          <span class="align-middle">
-            <item.icon class="inline-block mr-2" />
-            {item.inner}
-          </span>
-        </a>
-      ))}
+    <nav class="w-full md:w-[16rem] md:flex-shrink-0 ">
+      <ul class="flex flex-col justify-start">
+        {props.items.map((item) => (
+          <li
+            class={`px-4 py-2 rounded w-full ${
+              item.href === props.active
+                ? "bg-gray-100 font-bold"
+                : "hover:bg-gray-100"
+            }`}
+          >
+            <a
+              href={item.href}
+            >
+              <span class="align-middle">
+                <item.icon class="inline-block mr-2" />
+                {item.inner}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
     </nav>
   );
 }

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -7,12 +7,18 @@ interface NavProps extends JSX.HTMLAttributes<HTMLElement> {
 
 export default function Nav(props: NavProps) {
   return (
-    <nav
-      class={`flex gap-x-8 gap-y-2 items-center justify-between ${
-        props.class ?? ""
-      }`}
-    >
-      {props.items.map((item) => <a href={item.href}>{item.inner}</a>)}
+    <nav>
+      <ul
+        class={`flex gap-x-8 gap-y-2 items-center justify-between ${
+          props.class ?? ""
+        }`}
+      >
+        {props.items.map((item) => (
+          <li>
+            <a href={item.href}>{item.inner}</a>
+          </li>
+        ))}
+      </ul>
     </nav>
   );
 }


### PR DESCRIPTION
This PR improves the semantics of `nav` elements to be "more correct", according to [documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav#examples).