### PR TITLE
fix: dummy Stripe API key

### DIFF
--- a/utils/stripe.ts
+++ b/utils/stripe.ts
@@ -1,10 +1,23 @@
 import Stripe from "stripe";
 
-export const stripe = new Stripe(Deno.env.get("STRIPE_SECRET_KEY")!, {
-  apiVersion: "2022-11-15",
-  // Use the Fetch API instead of Node's HTTP client.
-  httpClient: Stripe.createFetchHttpClient(),
-});
+/** This constant allows preview deployments to successfully start up, making everything outside of the dashboard viewable. */
+const DUMMY_API_KEY =
+  "sk_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+if (!Deno.env.get("STRIPE_SECRET_KEY")) {
+  console.warn(
+    "`STRIPE_SECRET_KEY` environment variable is not defined. Dummy Stripe API key is currently in use. Stripe functionality is now limited.",
+  );
+}
+
+export const stripe = new Stripe(
+  Deno.env.get("STRIPE_SECRET_KEY") ?? DUMMY_API_KEY,
+  {
+    apiVersion: "2022-11-15",
+    // Use the Fetch API instead of Node's HTTP client.
+    httpClient: Stripe.createFetchHttpClient(),
+  },
+);
 
 export function formatAmountForDisplay(
   amount: number,

--- a/utils/stripe.ts
+++ b/utils/stripe.ts
@@ -1,7 +1,7 @@
 import Stripe from "stripe";
 
 /** This constant allows preview deployments to successfully start up, making everything outside of the dashboard viewable. */
-const DUMMY_API_KEY =
+const DUMMY_SECRET_KEY =
   "sk_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
 if (!Deno.env.get("STRIPE_SECRET_KEY")) {
@@ -11,7 +11,7 @@ if (!Deno.env.get("STRIPE_SECRET_KEY")) {
 }
 
 export const stripe = new Stripe(
-  Deno.env.get("STRIPE_SECRET_KEY") ?? DUMMY_API_KEY,
+  Deno.env.get("STRIPE_SECRET_KEY") ?? DUMMY_SECRET_KEY,
   {
     apiVersion: "2022-11-15",
     // Use the Fetch API instead of Node's HTTP client.


### PR DESCRIPTION
Previously, preview deployments would fail because the `STRIPE_SECRET_KEY` environment variable couldn't be read as part of a limitation of Deno Deploy.

Now, a dummy Stripe secret key is used as a fallback, so preview deployments work to a certain extent. Any pages needing to use the `stripe` instance won't work.