### PR TITLE
refactor: `createOrGetCustomer()` in middleware state

### DIFF
--- a/routes/dashboard/_middleware.ts
+++ b/routes/dashboard/_middleware.ts
@@ -8,7 +8,9 @@ import { stripe } from "@/utils/stripe.ts";
 export interface DashboardState {
   session: Session;
   supabaseClient: SupabaseClient<Database>;
-  customer: Database["public"]["Tables"]["customers"]["Insert"];
+  createOrGetCustomer: () => Promise<
+    Database["public"]["Tables"]["customers"]["Row"]
+  >;
 }
 
 export function getLoginPath(redirectUrl: string) {
@@ -29,7 +31,8 @@ export async function handler(
 
     ctx.state.session = session;
     ctx.state.supabaseClient = supabaseClient;
-    ctx.state.customer = await createOrGetCustomer(supabaseClient, stripe);
+    ctx.state.createOrGetCustomer = async () =>
+      await createOrGetCustomer(supabaseClient, stripe);
 
     const response = await ctx.next();
     /**

--- a/routes/dashboard/account.tsx
+++ b/routes/dashboard/account.tsx
@@ -2,14 +2,20 @@ import type { Handlers, PageProps } from "$fresh/server.ts";
 import Head from "@/components/Head.tsx";
 import type { DashboardState } from "./_middleware.ts";
 import Dashboard from "@/components/Dashboard.tsx";
+import type { Database } from "@/utils/supabase_types.ts";
 
-export const handler: Handlers<DashboardState, DashboardState> = {
-  GET(_request, ctx) {
-    return ctx.render(ctx.state);
+interface AccountPageData extends DashboardState {
+  customer: Database["public"]["Tables"]["customers"]["Row"];
+}
+
+export const handler: Handlers<AccountPageData, DashboardState> = {
+  async GET(_request, ctx) {
+    const customer = await ctx.state.createOrGetCustomer();
+    return ctx.render({ ...ctx.state, customer });
   },
 };
 
-export default function AccountPage(props: PageProps<DashboardState>) {
+export default function AccountPage(props: PageProps<AccountPageData>) {
   const action = props.data.customer.is_subscribed ? "Manage" : "Upgrade";
 
   return (

--- a/routes/dashboard/manage-subscription.ts
+++ b/routes/dashboard/manage-subscription.ts
@@ -5,8 +5,9 @@ import { DashboardState } from "./_middleware.ts";
 // deno-lint-ignore no-explicit-any
 export const handler: Handlers<any, DashboardState> = {
   async GET(request, ctx) {
+    const customer = await ctx.state.createOrGetCustomer();
     const { url } = await stripe.billingPortal.sessions.create({
-      customer: ctx.state.customer.stripe_customer_id,
+      customer: customer.stripe_customer_id,
       return_url: new URL(request.url).origin + "/dashboard",
     });
 

--- a/routes/dashboard/todos.tsx
+++ b/routes/dashboard/todos.tsx
@@ -7,21 +7,24 @@ import { DashboardState } from "./_middleware.ts";
 import Dashboard from "@/components/Dashboard.tsx";
 import { Database } from "@/utils/supabase_types.ts";
 
-interface TodosPageProps extends DashboardState {
+interface TodosPageData extends DashboardState {
   todos: Database["public"]["Tables"]["todos"]["Insert"][];
+  customer: Database["public"]["Tables"]["customers"]["Row"];
 }
 
-export const handler: Handlers<TodosPageProps, DashboardState> = {
+export const handler: Handlers<TodosPageData, DashboardState> = {
   async GET(_request, ctx) {
+    const customer = await ctx.state.createOrGetCustomer();
     const todos = await getTodos(ctx.state.supabaseClient);
     return ctx.render({
       ...ctx.state,
       todos,
+      customer,
     });
   },
 };
 
-export default function TodosPage(props: PageProps<TodosPageProps>) {
+export default function TodosPage(props: PageProps<TodosPageData>) {
   return (
     <>
       <Head title="Todos" />

--- a/routes/dashboard/upgrade-subscription.ts
+++ b/routes/dashboard/upgrade-subscription.ts
@@ -5,9 +5,10 @@ import { STRIPE_PREMIUM_PLAN_PRICE_ID } from "@/constants.ts";
 
 export const handler: Handlers<null, DashboardState> = {
   async GET(request, ctx) {
+    const customer = await ctx.state.createOrGetCustomer();
     const { url } = await stripe.checkout.sessions.create({
       success_url: new URL(request.url).origin + "/dashboard/todos",
-      customer: ctx.state.customer.stripe_customer_id,
+      customer: customer.stripe_customer_id,
       line_items: [
         {
           price: STRIPE_PREMIUM_PLAN_PRICE_ID,


### PR DESCRIPTION
Previously, `createOrGetCustomer()` was called every time a `/dashboard/**` request was made.

Now, `createOrGetCustomer()` to the `/dashboard` middleware context so it can be called only when needed.

Ref:
* https://github.com/denoland/saaskit/pull/16#discussion_r1154137671