### PR TITLE
feat: add general footer to blog pages

### DIFF
--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -4,7 +4,11 @@ import { Head } from "$fresh/runtime.ts";
 import { getPost, Post } from "@/utils/posts.ts";
 import Nav from "@/components/Nav.tsx";
 import Header from "@/components/Header.tsx";
-import { BlogHeaderNavItems } from "@/routes/blog/index.tsx";
+import {
+  BlogFooterNavItems,
+  BlogHeaderNavItems,
+} from "@/routes/blog/index.tsx";
+import Footer from "@/components/Footer.tsx";
 
 export const handler: Handlers<Post> = {
   async GET(_req, ctx) {
@@ -42,6 +46,9 @@ export default function PostPage(props: PageProps<Post>) {
           dangerouslySetInnerHTML={{ __html: render(post.content) }}
         />
       </main>
+      <Footer>
+        <Nav items={BlogFooterNavItems} />
+      </Footer>
     </>
   );
 }

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -1,15 +1,31 @@
 import { Handlers } from "$fresh/server.ts";
 import { PageProps } from "$fresh/server.ts";
 import { Head } from "$fresh/runtime.ts";
-import Header from "../../components/Header.tsx";
-import Nav from "../../components/Nav.tsx";
-import PostCard from "../../components/PostCard.tsx";
-import { getPosts, Post } from "../../utils/posts.ts";
+import Header from "@/components/Header.tsx";
+import Nav from "@/components/Nav.tsx";
+import PostCard from "@/components/PostCard.tsx";
+import { getPosts, Post } from "@/utils/posts.ts";
+import Footer from "@/components/Footer.tsx";
 
 export const BlogHeaderNavItems = [
   {
     href: "/blog",
     inner: "Blog",
+  },
+];
+
+export const BlogFooterNavItems = [
+  {
+    inner: "Features",
+    href: "/#features",
+  },
+  {
+    inner: "Pricing",
+    href: "/#pricing",
+  },
+  {
+    inner: "Testimonial",
+    href: "/#testimonial",
   },
 ];
 
@@ -29,6 +45,9 @@ export default function BlogIndexPage(props: PageProps<Post[]>) {
           {posts.map((post) => <PostCard post={post} />)}
         </div>
       </main>
+      <Footer>
+        <Nav items={BlogFooterNavItems} />
+      </Footer>
     </>
   );
 }


### PR DESCRIPTION
This PR adds a footer to the `/blog` and `/blog/<slug>` pages. For this I used the nav links already used on the landing page. 

Fix #29 