### PR TITLE
fix: pricing image sizing

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -156,7 +156,9 @@ function PricingSection(props: { products: Stripe.Product[] }) {
         subtitle="Some copy about pricing."
       />
       <div class="flex flex-col md:flex-row gap-8">
-        <img src="/pricing.svg" alt="Pricing image" class="flex-1" />
+        <div class="flex-1">
+          <img src="/pricing.svg" alt="Pricing image" />
+        </div>
         <div class="flex-1 flex flex-col gap-8">
           <PricingCard
             name="Free tier"


### PR DESCRIPTION
Before:
![Screenshot 2023-04-05 at 3 19 19 pm](https://user-images.githubusercontent.com/29347852/229988070-b36af828-9ef8-42b0-9165-9dede8cef45a.png)

After:
![Screenshot 2023-04-05 at 3 19 42 pm](https://user-images.githubusercontent.com/29347852/229988088-79089f94-2bcb-42a0-bf99-06d1195915da.png)