### PR TITLE
fix: unneeded assertion and cleanup

### DIFF
--- a/routes/dashboard/_middleware.ts
+++ b/routes/dashboard/_middleware.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
 import { createOrGetCustomer, createSupabaseClient } from "@/utils/supabase.ts";
-import { assert } from "std/testing/asserts.ts";
 import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import { Database } from "@/utils/supabase_types.ts";
 import { stripe } from "@/utils/stripe.ts";
@@ -14,42 +13,34 @@ export interface DashboardState {
   >;
 }
 
-export function getLoginPath(redirectUrl: string) {
-  const params = new URLSearchParams({ redirect_url: redirectUrl });
-  return `/login?${params}`;
-}
-
 export async function handler(
   request: Request,
   ctx: MiddlewareHandlerContext<DashboardState>,
 ) {
-  try {
-    const headers = new Headers();
-    const supabaseClient = createSupabaseClient(request.headers, headers);
+  const headers = new Headers();
+  const supabaseClient = createSupabaseClient(request.headers, headers);
 
-    const { data: { session } } = await supabaseClient.auth.getSession();
-    assert(session);
-
-    ctx.state.session = session;
-    ctx.state.supabaseClient = supabaseClient;
-    ctx.state.createOrGetCustomer = async () =>
-      await createOrGetCustomer(supabaseClient, stripe);
-
-    const response = await ctx.next();
-    /**
-     * Note: ensure that a `new Response()` with a `location` header is used when performing server-side redirects.
-     * Using `Response.redirect()` will throw as its headers are immutable.
-     */
-    headers.forEach((value, key) => response.headers.set(key, value));
-    return response;
-  } catch (error) {
-    console.error(error);
-
+  const { data: { session } } = await supabaseClient.auth.getSession();
+  if (!session) {
+    const params = new URLSearchParams({ redirect_url: request.url });
     return new Response(null, {
       status: 302,
       headers: {
-        location: getLoginPath(request.url),
+        location: `/login?${params}`,
       },
     });
   }
+
+  ctx.state.session = session;
+  ctx.state.supabaseClient = supabaseClient;
+  ctx.state.createOrGetCustomer = async () =>
+    await createOrGetCustomer(supabaseClient, stripe);
+
+  const response = await ctx.next();
+  /**
+   * Note: ensure that a `new Response()` with a `location` header is used when performing server-side redirects.
+   * Using `Response.redirect()` will throw as its headers are immutable.
+   */
+  headers.forEach((value, key) => response.headers.set(key, value));
+  return response;
 }


### PR DESCRIPTION
This change removes an unneeded assertion and `getLoginPath()`. This assertion was seemed misleading as having a nully `session` object isn't an error.