### PR TITLE
feat: `deno task init:stripe` and further documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,43 +73,11 @@ This will automatically configure the database tables and their settings for us.
 
 ### Payments
 
-1. Create the “Premium tier” product in Stripe via the Stripe CLI:
-
-```
-stripe products create \
-  --name="Premium tier" \
-  --default-price-data.unit-amount=500 \
-  --default-price-data.currency=usd \
-  --default-price-data.recurring.interval=month \
-  --description="Unlimited todos"
-```
-
-2. The resulting [product object](https://stripe.com/docs/api/products) will be
-   printed in the terminal. Copy the `default_price` value as
-   `STRIPE_PREMIUM_PLAN_PRICE_ID` in [`constants.ts`](constants.ts).
-
-3. Next, head over to
-   [your Stripe dashboard settings](https://dashboard.stripe.com/test/apikeys)
-   to copy the `STRIPE_SECRET_KEY` into your `.env` file. We recommend using the
-   test key for your development environment.
-
-4. Configure Stripe's customer portal settings:
-
-5. Ensure your users can manage their subscription via Stripe's Customer portal
-   by going to
-   [your Customer Portal settings](https://dashboard.stripe.com/test/settings/billing/portal)
-   and toggling on:
-
-- Payment methods > Allow customers to view and update payment methods.
-- Cancellations > Cancel subscriptions
-- Subscriptions > Customers can switch plans (and select your relevant
-  subscription tiers)
-
-Hit save.
-
-5. (Optional)
-   [Set up your branding on Stripe](https://dashboard.stripe.com/settings/branding),
-   as a user will be taken to Stripe's checkout page when they upgrade.
+1. Copy your Stripe secret key as `STRIPE_SECRET_KEY` into your `.env` file. We
+   recommend using the test key for your development environment.
+1. Run `deno task init:stripe` and follow the instructions. This automatically
+   creates your "Premium tier" product and configures the Stripe customer
+   portal.
 
 #### Updating `customers` database via Stripe webhooks
 
@@ -155,7 +123,7 @@ Once Docker and Supabase services are running, start the project with:
 deno task start
 ```
 
-Then, point your browser to `localhost:8000`.
+Then, point your browser to `http://localhost:8000`.
 
 ## Deploying to Production
 
@@ -166,6 +134,9 @@ This section shows how to get your SaaS ready for production and deploy it.
 TODO
 
 ### Payments
+
+[Set up your branding on Stripe](https://dashboard.stripe.com/settings/branding),
+as a user will be taken to Stripe's checkout page when they upgrade.
 
 Keep your `customers` database up to date with billing changes by
 [registering a webhook endpoint in Stripe](https://stripe.com/docs/development/dashboard/register-webhook).

--- a/README.md
+++ b/README.md
@@ -71,36 +71,39 @@ This will automatically configure the database tables and their settings for us.
    file as `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_KEY`,
    respectively.
 
-### Payments
+### Payments and Subscriptions
 
 1. Copy your Stripe secret key as `STRIPE_SECRET_KEY` into your `.env` file. We
    recommend using the test key for your development environment.
-1. Run `deno task init:stripe` and follow the instructions. This automatically
+2. Run `deno task init:stripe` and follow the instructions. This automatically
    creates your "Premium tier" product and configures the Stripe customer
    portal.
 
-#### Updating `customers` database via Stripe webhooks
+> Note: go to [init/stripe.ts] if you'd like to learn more about how the
+> `init:stripe` task works.
 
-Keep your `customers` database up to date with billing changes by
-[registering a webhook endpoint in Stripe](https://stripe.com/docs/development/dashboard/register-webhook).
-
-To test locally, use the Stripe CLI:
+3. Listen locally to Stripe events:
 
 ```
 stripe listen --forward-to localhost:8000/api/subscription
 ```
 
-You'll receive an output that includes your webhook signing secret. Copy that
-into your `.env` file as `STRIPE_WEBHOOK_SECRET`.
+4. Copy the webhook signing secret to [.env](.env) as `STRIPE_WEBHOOK_SECRET`.
 
-Start the server with `deno task start` and test the webhook with
-`stripe trigger customer.subscription.created` or
-`stripe trigger customer.subscription.deleted`.
+### Running the Server
 
-#### Testing Payments
+Finally, start the server by running:
 
-You can use [Stripe's test credit cards](https://stripe.com/docs/testing) to
-make test payments while in Stripe's test mode.
+```
+deno task start
+```
+
+Go to [http://localhost:8000](http://localhost:8000) to begin playing with your
+new SaaS app.
+
+> Note: You can use
+> [Stripe's test credit cards](https://stripe.com/docs/testing) to make test
+> payments while in Stripe's test mode.
 
 ### Global Constants
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ This will automatically configure the database tables and their settings for us.
    creates your "Premium tier" product and configures the Stripe customer
    portal.
 
-> Note: go to [init/stripe.ts] if you'd like to learn more about how the
-> `init:stripe` task works.
+> Note: go to [init/stripe.ts](init/stripe.ts) if you'd like to learn more about
+> how the `init:stripe` task works.
 
 3. Listen locally to Stripe events:
 

--- a/README.md
+++ b/README.md
@@ -105,16 +105,6 @@ new SaaS app.
 > [Stripe's test credit cards](https://stripe.com/docs/testing) to make test
 > payments while in Stripe's test mode.
 
-### Running Locally
-
-Once Docker and Supabase services are running, start the project with:
-
-```
-deno task start
-```
-
-Then, point your browser to `http://localhost:8000`.
-
 ## Deploying to Production
 
 This section shows how to get your SaaS ready for production and deploy it.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cd saaskit
 cp .example.env .env
 ```
 
-### Auth and Database
+### Auth and Database (Supabase)
 
 The values of these environmental variables will be gathered in the following
 steps.
@@ -71,7 +71,7 @@ This will automatically configure the database tables and their settings for us.
    file as `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_KEY`,
    respectively.
 
-### Payments and Subscriptions
+### Payments and Subscriptions (Stripe)
 
 1. Copy your Stripe secret key as `STRIPE_SECRET_KEY` into your `.env` file. We
    recommend using the test key for your development environment.

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "lock": false,
   "tasks": {
+    "init:stripe": "deno run --allow-read --allow-env --allow-net init/stripe.ts ",
     "start": "deno run -A --watch=static/,routes/ dev.ts",
     "test": "deno test -A",
     "check:license": "deno run --allow-read tools/check_license.ts"

--- a/dev.ts
+++ b/dev.ts
@@ -2,8 +2,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 
 import dev from "$fresh/dev.ts";
-import { load } from "std/dotenv/mod.ts";
-
-load({ export: true });
+import "std/dotenv/load.ts";
 
 await dev(import.meta.url, "./main.ts");

--- a/init/stripe.ts
+++ b/init/stripe.ts
@@ -1,0 +1,70 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import type { Stripe } from "stripe";
+import { SITE_DESCRIPTION } from "@/constants.ts";
+import "std/dotenv/load.ts";
+import { stripe } from "@/utils/stripe.ts";
+
+async function createPremiumTierProduct(stripe: Stripe) {
+  return await stripe.products.create({
+    name: "Premium tier",
+    description: "Unlimited todos",
+    default_price_data: {
+      unit_amount: 500,
+      currency: "usd",
+      recurring: {
+        interval: "month",
+      },
+    },
+  });
+}
+
+async function createDefaultPortalConfiguration(
+  stripe: Stripe,
+  product:
+    Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.Product,
+) {
+  return await stripe.billingPortal.configurations.create({
+    features: {
+      payment_method_update: {
+        enabled: true,
+      },
+      customer_update: {
+        allowed_updates: ["email", "name"],
+        enabled: true,
+      },
+      subscription_cancel: {
+        enabled: true,
+        mode: "immediately",
+      },
+      subscription_update: {
+        enabled: true,
+        default_allowed_updates: ["price"],
+        products: [product],
+      },
+      invoice_history: { enabled: true },
+    },
+    business_profile: {
+      headline: SITE_DESCRIPTION,
+    },
+  });
+}
+
+async function main() {
+  const product = await createPremiumTierProduct(stripe);
+
+  if (typeof product.default_price !== "string") return;
+
+  await createDefaultPortalConfiguration(stripe, {
+    prices: [product.default_price],
+    product: product.id,
+  });
+
+  console.log(
+    "Please copy and paste this value into the `STRIPE_PREMIUM_PLAN_PRICE_ID` constant in `constants.ts`: " +
+      product.default_price,
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/init/stripe.ts
+++ b/init/stripe.ts
@@ -5,7 +5,10 @@ import "std/dotenv/load.ts";
 import { stripe } from "@/utils/stripe.ts";
 
 async function createPremiumTierProduct(stripe: Stripe) {
-  // These parameters can be configured as you'd like.
+  /**
+   * These values provide a set of default values for the demo.
+   * However, these can be adjusted to fit your use case.
+   */
   return await stripe.products.create({
     name: "Premium tier",
     description: "Unlimited todos",

--- a/init/stripe.ts
+++ b/init/stripe.ts
@@ -5,6 +5,7 @@ import "std/dotenv/load.ts";
 import { stripe } from "@/utils/stripe.ts";
 
 async function createPremiumTierProduct(stripe: Stripe) {
+  // These parameters can be configured as you'd like.
   return await stripe.products.create({
     name: "Premium tier",
     description: "Unlimited todos",


### PR DESCRIPTION
Previously, a bit of manual work was required to set up Stripe. This change adds the init:stripe task, which:

1. Automatically creates the "Premium tier" product.
2. Automatically creates the default billing portal configuration used in the /dashboard/manage-subscription route.
3. Prints the "Premium tier" product price ID to be copied into constants.ts.

This dramatically reduces the time and steps needed and the chance of errors in setting up Stripe.

Contributors, please feel free to test and provide feedback.