### PR TITLE
docs: remove "Architecture" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,20 +158,6 @@ TODO
 
 TODO
 
-## Architecture
-
-### Authentication
-
-TODO:
-
-- Blog
-- Database
-- Formatting
-- Fresh
-- Linting
-- Payments
-- Testing
-
 ## Contributing
 
 When submitting a pull request, please:


### PR DESCRIPTION
See #75. These may be added back one day, but only once they've been flushed out. Either way, the aspects are tracked in the PR.

Towards #70.