### PR TITLE
fix: filter middleware routes

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -13,6 +13,11 @@ export async function handler(
   req: Request,
   ctx: MiddlewareHandlerContext<State>,
 ) {
+  const { pathname } = new URL(req.url);
+  if (["_frsh", ".ico", "logo"].some((part) => pathname.includes(part))) {
+    return await ctx.next();
+  }
+
   const headers = new Headers();
   const supabaseClient = createSupabaseClient(req.headers, headers);
 


### PR DESCRIPTION
Now, the top-level middleware doesn't process routes whose pathnames include `_frsh`, `.ico` or `logo`.