### PR TITLE
docs: added prod deploy db content to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,38 @@ SaaSKit comes with `primary` and `secondary` colors predefined within
 This section assumes that a
 [local development environment](#getting-started-locally) has been set up.
 
+### Database (Supabase)
+
+We'll use the Supabase CLI to migrate your local database to Supabase's remote
+production servers.
+
+1. Login with the Supabase CLI
+
+```sh
+supabase login
+```
+
+2. Run the Supabase link command to setup a local-remote project link
+
+- Get project-ref from the last part of the Supabase SaaSKit project URL:
+  https://app.supabase.com/project/{{ saaskit project-ref }}
+
+- Run `supabase link`:
+
+```sh
+supabase link --project-ref {{ supabase project ref }}
+```
+
+3. Run `supabase db push` to push the migration SQL (found in
+   `supabase/migrations`) to your remote Supabase account.
+
+```sh
+supabase db push
+```
+
+The database tables should now be in your remote Supabase project with
+[Row-Level Security policies configured](https://supabase.com/docs/guides/auth/row-level-security).
+
 ### Authentication (Supabase)
 
 These steps enable using email with Supabase Auth.


### PR DESCRIPTION
This edit seemed to have slipped through the cracks from our previous Production Deployment `README.md` update. I was able to recover it from a local version of #109 that I had.