### PR TITLE
fix/refactor: simplify db types and re-introduce `getOrCreateUser()`

### DIFF
--- a/components/ItemSummary.tsx
+++ b/components/ItemSummary.tsx
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import type { ItemValue } from "@/utils/db.ts";
+import type { Item } from "@/utils/db.ts";
 
 export function pluralize(unit: number, label: string) {
   return unit === 1 ? `${unit} ${label}` : `${unit} ${label}s`;
@@ -13,22 +13,22 @@ export function timeAgo(time: number | Date) {
   else return pluralize(~~(between / 86400), "day");
 }
 
-export default function ItemSummary(props: Deno.KvEntry<ItemValue>) {
+export default function ItemSummary(props: Item) {
   return (
     <div class="py-2">
       <div>
         <span class="cursor-pointer mr-2 text-gray-300">▲</span>
         <span class="mr-2">
-          <a href={props.value.url}>{props.value.title}</a>
+          <a href={props.url}>{props.title}</a>
         </span>
         <span class="text-gray-500">
-          {new URL(props.value.url).host}
+          {new URL(props.url).host}
         </span>
       </div>
       <div class="text-gray-500">
-        {pluralize(props.value.score, "point")} by {props.value.userId}{" "}
-        {timeAgo(new Date(props.value.createdAt))} ago •{" "}
-        <a href={`/item/${props.key.at(-1)}`}>
+        {pluralize(props.score, "point")} by {props.userId}{" "}
+        {timeAgo(new Date(props.createdAt))} ago •{" "}
+        <a href={`/item/${props.id}`}>
           Comments
         </a>
       </div>

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,11 +1,11 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
 import { createSupabaseClient } from "@/utils/auth.ts";
-import type { Session, SupabaseClient } from "@supabase/supabase-js";
+import type { Session } from "@supabase/supabase-js";
 
 export interface State {
   session: Session | null;
-  supabaseClient: SupabaseClient;
+  supabaseClient: ReturnType<typeof createSupabaseClient>;
   isLoggedIn: boolean;
 }
 

--- a/routes/account/index.tsx
+++ b/routes/account/index.tsx
@@ -4,16 +4,19 @@ import Head from "@/components/Head.tsx";
 import Layout from "@/components/Layout.tsx";
 import type { AccountState } from "./_middleware.ts";
 import { BUTTON_STYLES } from "@/utils/constants.ts";
-import { getUser, type UserValue } from "@/utils/db.ts";
+import { getOrCreateUser, type User } from "@/utils/db.ts";
 
 interface AccountPageData extends AccountState {
-  user: UserValue;
+  user: User;
 }
 
 export const handler: Handlers<AccountPageData, AccountState> = {
   async GET(_request, ctx) {
-    const user = await getUser(ctx.state.session.user.id);
-    return ctx.render({ ...ctx.state, user: user.value! });
+    const user = await getOrCreateUser(
+      ctx.state.session.user.id,
+      ctx.state.session.user.email!,
+    );
+    return user ? ctx.render({ ...ctx.state, user }) : ctx.renderNotFound();
   },
 };
 

--- a/routes/account/manage.ts
+++ b/routes/account/manage.ts
@@ -2,14 +2,18 @@
 import type { Handlers } from "$fresh/server.ts";
 import { stripe } from "@/utils/payments.ts";
 import type { AccountState } from "./_middleware.ts";
-import { getUser } from "@/utils/db.ts";
+import { getOrCreateUser } from "@/utils/db.ts";
 
 // deno-lint-ignore no-explicit-any
 export const handler: Handlers<any, AccountState> = {
   async GET(req, ctx) {
-    const user = await getUser(ctx.state.session.user.id);
+    const user = await getOrCreateUser(
+      ctx.state.session.user.id,
+      ctx.state.session.user.email!,
+    );
+
     const { url } = await stripe.billingPortal.sessions.create({
-      customer: user.value!.stripeCustomerId,
+      customer: user.stripeCustomerId,
       return_url: new URL(req.url).origin + "/account",
     });
 

--- a/routes/account/upgrade.ts
+++ b/routes/account/upgrade.ts
@@ -2,21 +2,22 @@
 import type { Handlers } from "$fresh/server.ts";
 import { stripe } from "@/utils/payments.ts";
 import type { AccountState } from "./_middleware.ts";
-import { getUser } from "@/utils/db.ts";
+import { getOrCreateUser } from "@/utils/db.ts";
 
 export const handler: Handlers<null, AccountState> = {
   async GET(req, ctx) {
     const STRIPE_PREMIUM_PLAN_PRICE_ID = Deno.env.get(
       "STRIPE_PREMIUM_PLAN_PRICE_ID",
     );
-    if (!STRIPE_PREMIUM_PLAN_PRICE_ID) {
-      return ctx.renderNotFound();
-    }
+    if (!STRIPE_PREMIUM_PLAN_PRICE_ID) return ctx.renderNotFound();
 
-    const user = await getUser(ctx.state.session.user.id);
+    const user = await getOrCreateUser(
+      ctx.state.session.user.id,
+      ctx.state.session.user.email!,
+    );
     const { url } = await stripe.checkout.sessions.create({
       success_url: new URL(req.url).origin + "/account",
-      customer: user.value?.stripeCustomerId,
+      customer: user.stripeCustomerId,
       line_items: [
         {
           price: STRIPE_PREMIUM_PLAN_PRICE_ID,

--- a/routes/api/stripe-webhooks.ts
+++ b/routes/api/stripe-webhooks.ts
@@ -2,10 +2,7 @@
 import type { Handlers } from "$fresh/server.ts";
 import { stripe } from "@/utils/payments.ts";
 import { Stripe } from "stripe";
-import {
-  getUserIdByStripeCustomerId,
-  setUserSubscription,
-} from "@/utils/db.ts";
+import { getUserByStripeCustomerId, setUserSubscription } from "@/utils/db.ts";
 
 const cryptoProvider = Stripe.createSubtleCryptoProvider();
 
@@ -39,15 +36,15 @@ export const handler: Handlers = {
 
     switch (event.type) {
       case "customer.subscription.created": {
-        const userId = await getUserIdByStripeCustomerId(customer);
-        if (userId === null) return new Response(null, { status: 400 });
-        await setUserSubscription(userId, true);
+        const user = await getUserByStripeCustomerId(customer);
+        if (!user) return new Response(null, { status: 400 });
+        await setUserSubscription(user.id, true);
         return new Response(null, { status: 201 });
       }
       case "customer.subscription.deleted": {
-        const userId = await getUserIdByStripeCustomerId(customer);
-        if (userId === null) return new Response(null, { status: 400 });
-        await setUserSubscription(userId, false);
+        const user = await getUserByStripeCustomerId(customer);
+        if (!user) return new Response(null, { status: 400 });
+        await setUserSubscription(user.id, false);
         return new Response(null, { status: 202 });
       }
       default: {

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -5,15 +5,15 @@ import Layout from "@/components/Layout.tsx";
 import Head from "@/components/Head.tsx";
 import type { State } from "./_middleware.ts";
 import ItemSummary from "@/components/ItemSummary.tsx";
-import { getItems, type ItemValue } from "@/utils/db.ts";
+import { getAllItems, type Item } from "@/utils/db.ts";
 
 interface HomePageData extends State {
-  items: Deno.KvEntry<ItemValue>[];
+  items: Item[];
 }
 
 export const handler: Handlers<HomePageData, State> = {
   async GET(_req, ctx) {
-    const items = await getItems();
+    const items = await getAllItems();
     return ctx.render({ ...ctx.state, items });
   },
 };

--- a/routes/item/[id].tsx
+++ b/routes/item/[id].tsx
@@ -11,30 +11,30 @@ import {
 } from "@/utils/constants.ts";
 import { timeAgo } from "@/components/ItemSummary.tsx";
 import {
-  CommentValue,
+  Comment,
   createComment,
-  getItem,
-  getItemComments,
-  ItemValue,
+  getCommentsByItem,
+  getItemById,
+  Item,
 } from "@/utils/db.ts";
 
 interface ItemPageData extends State {
-  itemRes: Deno.KvEntry<ItemValue>;
-  commentsRes: Deno.KvEntry<CommentValue>[];
+  item: Item;
+  comments: Comment[];
 }
 
 export const handler: Handlers<ItemPageData, State> = {
   async GET(_req, ctx) {
     const { id } = ctx.params;
 
-    const itemRes = await getItem(id);
-    if (itemRes.value === null) {
+    const item = await getItemById(id);
+    if (item === null) {
       return ctx.renderNotFound();
     }
 
-    const commentsRes = await getItemComments(id);
+    const comments = await getCommentsByItem(id);
 
-    return ctx.render({ ...ctx.state, itemRes, commentsRes });
+    return ctx.render({ ...ctx.state, item, comments });
   },
   async POST(req, ctx) {
     if (!ctx.state.session) {
@@ -67,26 +67,22 @@ export const handler: Handlers<ItemPageData, State> = {
   },
 };
 
-function Comment(comment: CommentValue) {
-  return (
-    <div class="py-4">
-      <p>{comment.userId}</p>
-      <p class="text-gray-500">{timeAgo(new Date(comment.createdAt))} ago</p>
-      <p>{comment.text}</p>
-    </div>
-  );
-}
-
 export default function ItemPage(props: PageProps<ItemPageData>) {
   return (
     <>
-      <Head title={props.data.itemRes.value.title} />
+      <Head title={props.data.item.title} />
       <Layout isLoggedIn={props.data.isLoggedIn}>
         <div class={`${SITE_WIDTH_STYLES} flex-1 px-8 space-y-4`}>
-          <ItemSummary {...props.data.itemRes} />
+          <ItemSummary {...props.data.item} />
           <div class="divide-y">
-            {props.data.commentsRes.map((comment) => (
-              <Comment {...comment.value} />
+            {props.data.comments.map((comment) => (
+              <div class="py-4">
+                <p>{comment.userId}</p>
+                <p class="text-gray-500">
+                  {timeAgo(new Date(comment.createdAt))} ago
+                </p>
+                <p>{comment.text}</p>
+              </div>
             ))}
           </div>
           <form method="post">

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -100,7 +100,7 @@ export interface User extends InitUser {
 export async function createUser(initUser: InitUser) {
   const usersKey = ["users", initUser.id];
   const stripeCustomersKey = [
-    "users_by_stripe_customer",
+    "user_ids_by_stripe_customer",
     initUser.stripeCustomerId,
   ];
   const user: User = { ...initUser, isSubscribed: false };
@@ -109,7 +109,7 @@ export async function createUser(initUser: InitUser) {
     .check({ key: usersKey, versionstamp: null })
     .check({ key: stripeCustomersKey, versionstamp: null })
     .set(usersKey, user)
-    .set(stripeCustomersKey, user)
+    .set(stripeCustomersKey, user.id)
     .commit();
 
   if (!res.ok) {
@@ -125,11 +125,12 @@ export async function getUserById(id: string) {
 }
 
 export async function getUserByStripeCustomerId(stripeCustomerId: string) {
-  const res = await kv.get<User>([
-    "users_by_stripe_customer",
+  const res = await kv.get<string>([
+    "user_ids_by_stripe_customer",
     stripeCustomerId,
   ]);
-  return res.value;
+  if (!res.value) return null;
+  return await getUserById(res.value);
 }
 
 export async function setUserSubscription(


### PR DESCRIPTION
This change:
* Simplifies how database objects are get and set by including the `id` property in the respective object. This means we can return the object's value, including the `id`, ignoring the key.
* Re-introduces `getOrCreateUser()`, which ensures a user object always exists. This is particularly valuable for OAuth users.

Fixes:
* #133