### PR TITLE
fix/refactor: improve middleware filter

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -2,6 +2,13 @@
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
 import { createSupabaseClient } from "@/utils/auth.ts";
 import type { Session, SupabaseClient } from "@supabase/supabase-js";
+import { walk } from "std/fs/walk.ts";
+
+const STATIC_DIR_ROOT = new URL("../static", import.meta.url);
+const staticFileNames: string[] = [];
+for await (const { name } of walk(STATIC_DIR_ROOT, { includeDirs: false })) {
+  staticFileNames.push(name);
+}
 
 export interface State {
   session: Session | null;
@@ -14,7 +21,8 @@ export async function handler(
   ctx: MiddlewareHandlerContext<State>,
 ) {
   const { pathname } = new URL(req.url);
-  if (["_frsh", ".ico", "logo"].some((part) => pathname.includes(part))) {
+  // Don't process session-related data for keepalive and static requests
+  if (["_frsh", ...staticFileNames].some((part) => pathname.includes(part))) {
     return await ctx.next();
   }
 

--- a/routes/logout.ts
+++ b/routes/logout.ts
@@ -5,8 +5,7 @@ import type { State } from "./_middleware.ts";
 // deno-lint-ignore no-explicit-any
 export const handler: Handlers<any, State> = {
   async GET(_req, ctx) {
-    const { error } = await ctx.state.supabaseClient
-      .auth.signOut();
+    const { error } = await ctx.state.supabaseClient.auth.signOut();
     if (error) throw error;
 
     return new Response(null, { headers: { location: "/" }, status: 302 });


### PR DESCRIPTION
Previously, the middleware filter was skipping on populating state for the logout route. This was because "logo", which was for the site logo, mistakenly added the **logo**ut route to the skip list.

This change ensures the `ctx.state` object is populated in the logout route and dynamically sets the skip list by whether the incoming request is a Fresh keepalive or static file request.