### PR TITLE
feat: re-enable OAuth

### DIFF
--- a/components/OAuthLoginButton.tsx
+++ b/components/OAuthLoginButton.tsx
@@ -15,8 +15,7 @@ export default function OAuthLoginButton(props: OAuthLoginButtonProps) {
       <button
         type="submit"
         class="px-4 py-2 w-full bg-white text-black text-lg rounded-lg border-2 border-black disabled:(opacity-50 cursor-not-allowed)"
-        /** @todo Pass `props.disabled` once OAuth and the `user` object play well together */
-        disabled
+        disabled={props.disabled}
       >
         {props.children}
       </button>


### PR DESCRIPTION
This change re-enables OAuth for preview and production deployments. This action was previously blocked by #133.

A further PR will enable OAuth for local development.

This has been tested and is working on the preview deployment.