### PR TITLE
refactor: simplify commentsCount logic

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -5,11 +5,7 @@ import Layout from "@/components/Layout.tsx";
 import Head from "@/components/Head.tsx";
 import type { State } from "./_middleware.ts";
 import ItemSummary from "@/components/ItemSummary.tsx";
-import {
-  getAllItems,
-  getItemCommentsCountsByIds,
-  type Item,
-} from "@/utils/db.ts";
+import { getAllItems, getItemCommentsCount, type Item } from "@/utils/db.ts";
 
 interface HomePageData extends State {
   items: Item[];
@@ -19,8 +15,8 @@ interface HomePageData extends State {
 export const handler: Handlers<HomePageData, State> = {
   async GET(_req, ctx) {
     const items = await getAllItems();
-    const commentsCounts = await getItemCommentsCountsByIds(
-      items.map((item) => item.id),
+    const commentsCounts = await Promise.all(
+      items.map((item) => getItemCommentsCount(item.id)),
     );
     return ctx.render({ ...ctx.state, items, commentsCounts });
   },

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -93,24 +93,11 @@ export async function getCommentsByItem(
   return comments;
 }
 
-export async function getItemCommentsCountsByIds(
-  ids: string[],
-  options?: Deno.KvListOptions,
-) {
-  const keys = ids.map((id) => ["comments_by_item", id]);
-  const items: number[] = [];
-  for (let i = 0; i < keys.length; i++) {
-    const iter = await kv.list<Comment>({
-      prefix: keys[i],
-    }, options);
-
-    let commentsCount = 0;
-    for await (const _ of iter) {
-      commentsCount++;
-    }
-    items.push(commentsCount);
-  }
-  return items;
+export async function getItemCommentsCount(itemId: string) {
+  const iter = kv.list<Comment>({ prefix: ["comments_by_item", itemId] });
+  let count = 0;
+  for await (const _ of iter) count++;
+  return count;
 }
 
 interface InitUser {


### PR DESCRIPTION
This will either fix the current server-side error or help in diagnosing it.
```
An error occurred during route handling or page rendering. TypeError: Error parsing args at position 2: expected string, number, bigint, ArrayBufferView, boolean
    at Object.opAsync (ext:core/01_core.js:256:30)
    at KvListIterator.<anonymous> (ext:deno_kv/01_db.ts:107:42)
    at KvListIterator.next (ext:deno_kv/01_db.ts:379:48)
    at getItemCommentsCountsByIds (file:///src/utils/db.ts:105:26)
    at eventLoopTick (ext:core/01_core.js:165:11)
    at async GET (file:///src/routes/index.tsx:11:32)
    at async https://deno.land/x/rutt@0.1.0/mod.ts:143:36
    at async handler (file:///src/routes/_middleware.ts:26:22)
    at async Server.handler (https://deno.land/x/fresh@1.1.5/src/server/context.ts:220:25)
    at async Server.#respond (https://deno.land/std@0.178.0/http/server.ts:220:24)
```