### PR TITLE
feat: export `resetKv()`

### DIFF
--- a/tools/reset_kv.ts
+++ b/tools/reset_kv.ts
@@ -1,17 +1,22 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { kv } from "@/utils/db.ts";
 
-if (
-  !confirm(
-    "This script deletes all data from the Deno KV database. Are you sure you'd like to continue?",
-  )
-) {
-  close();
+export async function resetKv() {
+  const iter = kv.list({ prefix: [] });
+  const promises = [];
+  for await (const res of iter) promises.push(kv.delete(res.key));
+  await Promise.all(promises);
+
+  await kv.close();
 }
 
-const iter = kv.list({ prefix: [] });
-const promises = [];
-for await (const res of iter) promises.push(kv.delete(res.key));
-await Promise.all(promises);
-
-await kv.close();
+if (import.meta.main) {
+  if (
+    !confirm(
+      "This script deletes all data from the Deno KV database. Are you sure you'd like to continue?",
+    )
+  ) {
+    close();
+  }
+  await resetKv();
+}


### PR DESCRIPTION
This will be useful for running one-off database data resets in deployment.