### PR TITLE
chore: one-time data reset

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -11,4 +11,8 @@ import manifest from "./fresh.gen.ts";
 import twindPlugin from "$fresh/plugins/twindv1.ts";
 import twindConfig from "./twind.config.ts";
 
+// Note: this is a one-off database reset as such functionality doesn't exist in Deno Deploy.
+import { resetKv } from "./tools/reset_kv.ts";
+await resetKv();
+
 await start(manifest, { plugins: [twindPlugin(twindConfig)] });

--- a/tools/reset_kv.ts
+++ b/tools/reset_kv.ts
@@ -6,8 +6,6 @@ export async function resetKv() {
   const promises = [];
   for await (const res of iter) promises.push(kv.delete(res.key));
   await Promise.all(promises);
-
-  await kv.close();
 }
 
 if (import.meta.main) {
@@ -19,4 +17,5 @@ if (import.meta.main) {
     close();
   }
   await resetKv();
+  await kv.close();
 }


### PR DESCRIPTION
Due to recent database changes, this must be run once in preview and production deployments.