### PR TITLE
fix: tailwind option types

### DIFF
--- a/twind.config.ts
+++ b/twind.config.ts
@@ -1,16 +1,18 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import type { Options } from "$fresh/plugins/twindv1.ts";
-import { defineConfig } from "twind";
+import { Options } from "$fresh/plugins/twindv1.ts";
+import { defineConfig, Preset } from "twind";
 // twind preset
 import presetAutoPrefix from "twind-preset-autoprefix";
 import presetTailWind from "twind-preset-tailwind";
 import * as colors from "twind-preset-tailwind-colors";
 
+/** @todo Remove the need for type-assertions */
 export default {
   selfURL: import.meta.url,
+  // <BaseTheme, Preset<any>[]>
   ...defineConfig({
     presets: [
-      presetAutoPrefix(),
+      presetAutoPrefix() as Preset,
       presetTailWind({
         colors: {
           // This line is required. Otherwise, if removed, the values of other colors with be removed.
@@ -19,7 +21,8 @@ export default {
           primary: "#4f06be",
           secondary: "#170139",
         },
-      }),
+        // deno-lint-ignore no-explicit-any
+      }) as Preset<any>,
     ],
   }),
 } as Options;


### PR DESCRIPTION
This fixes current type-checking failures. This is a band-aid fix and should be fully looked into at some point.