### PR TITLE
refactor: remove `isLoggedIn` property

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -7,6 +7,7 @@ import {
   SITE_WIDTH_STYLES,
 } from "@/utils/constants.ts";
 import Logo from "./Logo.tsx";
+import type { Session } from "@supabase/supabase-js";
 
 function Notice() {
   return (
@@ -82,7 +83,7 @@ function Footer(props: JSX.HTMLAttributes<HTMLElement>) {
 
 interface LayoutProps {
   children: ComponentChildren;
-  isLoggedIn: boolean;
+  session: Session | null;
 }
 
 export default function Layout(props: LayoutProps) {
@@ -91,7 +92,7 @@ export default function Layout(props: LayoutProps) {
       href: "/submit",
       inner: <span class={BUTTON_STYLES}>Submit</span>,
     },
-    props.isLoggedIn
+    props.session
       ? {
         href: "/account",
         inner: "Account",

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -13,7 +13,6 @@ for await (const { name } of walk(STATIC_DIR_ROOT, { includeDirs: false })) {
 export interface State {
   session: Session | null;
   supabaseClient: ReturnType<typeof createSupabaseClient>;
-  isLoggedIn: boolean;
 }
 
 export async function handler(
@@ -33,7 +32,6 @@ export async function handler(
 
   ctx.state.session = session;
   ctx.state.supabaseClient = supabaseClient;
-  ctx.state.isLoggedIn = Boolean(session);
 
   const response = await ctx.next();
   /**

--- a/routes/account/index.tsx
+++ b/routes/account/index.tsx
@@ -29,7 +29,7 @@ export default function AccountPage(props: PageProps<AccountPageData>) {
   return (
     <>
       <Head title="Account" />
-      <Layout isLoggedIn={props.data.isLoggedIn}>
+      <Layout session={props.data.session}>
         <div class="max-w-lg m-auto w-full flex-1 p-8 flex flex-col justify-center">
           <h1 class="text-3xl mb-4">
             <strong>Account</strong>

--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -39,7 +39,7 @@ export default function PostPage(props: PageProps<BlogPostPageData>) {
           href={props.url.href}
         />
       </Head>
-      <Layout isLoggedIn={props.data.isLoggedIn}>
+      <Layout session={props.data.session}>
         <main class={`${SITE_WIDTH_STYLES} px-8 pt-16 flex-1`}>
           <h1 class="text-5xl font-bold">{post.title}</h1>
           <time class="text-gray-500">

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -28,7 +28,7 @@ export default function BlogPage(props: PageProps<BlogPageData>) {
         description="This is the blog for Deno SaaSKit"
         href={props.url.href}
       />
-      <Layout isLoggedIn={props.data.isLoggedIn}>
+      <Layout session={props.data.session}>
         <main class={`${SITE_WIDTH_STYLES} px-8 pt-16 flex-1`}>
           <h1 class="text-5xl font-bold">Blog</h1>
           <div class="mt-8">

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -34,7 +34,7 @@ export default function HomePage(props: PageProps<HomePageData>) {
   return (
     <>
       <Head />
-      <Layout isLoggedIn={props.data.isLoggedIn}>
+      <Layout session={props.data.session}>
         <div class={`${SITE_WIDTH_STYLES} divide-y flex-1 px-8`}>
           {props.data.items.map((item, index) => (
             <ItemSummary

--- a/routes/item/[id].tsx
+++ b/routes/item/[id].tsx
@@ -86,7 +86,7 @@ export default function ItemPage(props: PageProps<ItemPageData>) {
   return (
     <>
       <Head title={props.data.item.title} />
-      <Layout isLoggedIn={props.data.isLoggedIn}>
+      <Layout session={props.data.session}>
         <div class={`${SITE_WIDTH_STYLES} flex-1 px-8 space-y-4`}>
           <ItemSummary
             item={props.data.item}

--- a/routes/submit.tsx
+++ b/routes/submit.tsx
@@ -21,7 +21,7 @@ export const handler: Handlers<State, State> = {
     return ctx.render(ctx.state);
   },
   async POST(req, ctx) {
-    if (!ctx.state.isLoggedIn) {
+    if (!ctx.state.session) {
       await req.body?.cancel();
       return new Response(null, { status: 401 });
     }
@@ -82,7 +82,7 @@ export default function SubmitPage(props: PageProps<State>) {
   return (
     <>
       <Head title="Submit" />
-      <Layout isLoggedIn={props.data.isLoggedIn}>
+      <Layout session={props.data.session}>
         <div class="flex-1 flex flex-col justify-center max-w-sm mx-auto w-full space-y-8">
           <h1 class="text-center text-2xl font-bold">Share your project</h1>
           <Form />


### PR DESCRIPTION
`Session | null` has the same effect and is already present in the same places that `isLoggedIn` was. This is one less moving part.