### PR TITLE
fix: limit feed to 10 items

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -21,7 +21,7 @@ interface HomePageData extends State {
 
 export const handler: Handlers<HomePageData, State> = {
   async GET(_req, ctx) {
-    const items = await getAllItems();
+    const items = (await getAllItems()).slice(0, 10);
     const users = await getUsersByIds(items.map((item) => item.userId));
     const commentsCounts = await Promise.all(
       items.map((item) => getItemCommentsCount(item.id)),


### PR DESCRIPTION
It seems as though `Deno.Kv.getMany()` has a limit of 10 entries. This appears to be a hard limit independent of consistency level. This will need to be investigated further and may require pagination in the future.