### PR TITLE
refactor: remove comments count

### DIFF
--- a/components/ItemSummary.tsx
+++ b/components/ItemSummary.tsx
@@ -1,7 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import VoteButton from "@/islands/VoteButton.tsx";
 import { getUserDisplayName, Item, User } from "@/utils/db.ts";
-import IconExternalLink from "tabler_icons_tsx/tsx/external-link.tsx";
 
 export function pluralize(unit: number, label: string) {
   return unit === 1 ? `${unit} ${label}` : `${unit} ${label}s`;
@@ -35,9 +34,8 @@ export default function ItemSummary(props: ItemSummaryProps) {
           </a>
         </span>
         <span>
-          <a class="hover:underline" href={props.item.url}>
-            {new URL(props.item.url).host}{" "}
-            <IconExternalLink class="w-4 h-4 align-middle inline-block" />
+          <a class="hover:underline" href={props.item.url} target="_blank">
+            {new URL(props.item.url).host} ↗
           </a>
         </span>
         <p>

--- a/components/ItemSummary.tsx
+++ b/components/ItemSummary.tsx
@@ -1,6 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import VoteButton from "@/islands/VoteButton.tsx";
 import { getUserDisplayName, Item, User } from "@/utils/db.ts";
+import IconExternalLink from "tabler_icons_tsx/tsx/external-link.tsx";
 
 export function pluralize(unit: number, label: string) {
   return unit === 1 ? `${unit} ${label}` : `${unit} ${label}s`;
@@ -17,7 +18,6 @@ export function timeAgo(time: number | Date) {
 export interface ItemSummaryProps {
   item: Item;
   user: User;
-  commentsCount: number;
   isVoted: boolean;
 }
 
@@ -29,19 +29,23 @@ export default function ItemSummary(props: ItemSummaryProps) {
         isVoted={props.isVoted}
       />
       <div>
-        <span class="mr-2 text-black">
-          <a href={props.item.url}>{props.item.title}</a>
+        <span class="mr-2">
+          <a class="text-black hover:underline" href={`/item/${props.item.id}`}>
+            {props.item.title}
+          </a>
         </span>
-        {new URL(props.item.url).host}
+        <span>
+          <a class="hover:underline" href={props.item.url}>
+            {new URL(props.item.url).host}{" "}
+            <IconExternalLink class="w-4 h-4 align-middle inline-block" />
+          </a>
+        </span>
         <p>
           {getUserDisplayName(props.user)}{" "}
           {props.user.isSubscribed && (
             <span title="Deno Hunt premium user">🦕{" "}</span>
           )}
-          {timeAgo(new Date(props.item.createdAt))} ago •{" "}
-          <a href={`/item/${props.item.id}`}>
-            {pluralize(props.commentsCount, "comment")}
-          </a>
+          {timeAgo(new Date(props.item.createdAt))} ago
         </p>
       </div>
     </div>

--- a/import_map.json
+++ b/import_map.json
@@ -16,7 +16,6 @@
     "stripe": "https://esm.sh/stripe@11.13.0",
     "@supabase/auth-helpers-shared": "https://esm.sh/@supabase/auth-helpers-shared@0.3.3?target=es2022",
     "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.14.0",
-    "feed": "https://esm.sh/feed@4.2.2",
-    "tabler_icons_tsx/": "https://deno.land/x/tabler_icons_tsx@0.0.3/"
+    "feed": "https://esm.sh/feed@4.2.2"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -16,6 +16,7 @@
     "stripe": "https://esm.sh/stripe@11.13.0",
     "@supabase/auth-helpers-shared": "https://esm.sh/@supabase/auth-helpers-shared@0.3.3?target=es2022",
     "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.14.0",
-    "feed": "https://esm.sh/feed@4.2.2"
+    "feed": "https://esm.sh/feed@4.2.2",
+    "tabler_icons_tsx/": "https://deno.land/x/tabler_icons_tsx@0.0.3/"
   }
 }

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -7,7 +7,6 @@ import type { State } from "./_middleware.ts";
 import ItemSummary from "@/components/ItemSummary.tsx";
 import {
   getAllItems,
-  getItemCommentsCount,
   getUsersByIds,
   getVotedItemIdsByUser,
   type Item,
@@ -17,7 +16,6 @@ import {
 interface HomePageData extends State {
   users: User[];
   items: Item[];
-  commentsCounts: number[];
   areVoted: boolean[];
 }
 
@@ -38,15 +36,12 @@ export const handler: Handlers<HomePageData, State> = {
     /** @todo Add pagination functionality */
     const items = (await getAllItems({ limit: 10 })).sort(compareScore);
     const users = await getUsersByIds(items.map((item) => item.userId));
-    const commentsCounts = await Promise.all(
-      items.map((item) => getItemCommentsCount(item.id)),
-    );
     const votedItemIds = ctx.state.session
       ? await getVotedItemIdsByUser(ctx.state.session?.user.id)
       : [];
     /** @todo Optimise */
     const areVoted = items.map((item) => votedItemIds.includes(item.id));
-    return ctx.render({ ...ctx.state, items, commentsCounts, users, areVoted });
+    return ctx.render({ ...ctx.state, items, users, areVoted });
   },
 };
 
@@ -59,7 +54,6 @@ export default function HomePage(props: PageProps<HomePageData>) {
           {props.data.items.map((item, index) => (
             <ItemSummary
               item={item}
-              commentsCount={props.data.commentsCounts[index]}
               isVoted={props.data.areVoted[index]}
               user={props.data.users[index]}
             />

--- a/routes/item/[id].tsx
+++ b/routes/item/[id].tsx
@@ -23,6 +23,7 @@ import {
   type User,
 } from "@/utils/db.ts";
 import { redirect } from "@/utils/http.ts";
+import { pluralize } from "@/components/ItemSummary.tsx";
 
 interface ItemPageData extends State {
   user: User;
@@ -89,14 +90,18 @@ export default function ItemPage(props: PageProps<ItemPageData>) {
     <>
       <Head title={props.data.item.title} href={props.url.href} />
       <Layout session={props.data.session}>
-        <div class={`${SITE_WIDTH_STYLES} flex-1 px-8 space-y-4`}>
+        <div class={`${SITE_WIDTH_STYLES} flex-1 px-8 space-y-8`}>
           <ItemSummary
             item={props.data.item}
-            commentsCount={props.data.comments.length}
             isVoted={props.data.isVoted}
             user={props.data.user}
           />
           <div>
+            <h2>
+              <strong>
+                {pluralize(props.data.comments.length, "comment")}
+              </strong>
+            </h2>
             {props.data.comments.map((comment, index) => (
               <div class="py-4">
                 <p>

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -98,13 +98,6 @@ export async function getCommentsByItem(
   return comments;
 }
 
-export async function getItemCommentsCount(itemId: string) {
-  const iter = kv.list<Comment>({ prefix: ["comments_by_item", itemId] });
-  let count = 0;
-  for await (const _ of iter) count++;
-  return count;
-}
-
 interface InitVote {
   userId: string;
   itemId: string;


### PR DESCRIPTION
This change removes the comments part of `<ItemSummary />`. [Previously](https://github.com/denoland/saaskit/pull/137), this was argued to be a good indicator of an interesting item. However, with the complexity and computational cost of such a minor feature and the onset of voting functionality, it's more reasonable not to have the feature. A vote score is a sufficient indicator of an item's value.

However, an item's comment count can still be seen on the item page, which is calculated without an extra database call through `comments.length`. A few other adjustments had to be made to make `<ItemSummary />` usable:
1. The item title now links to the item page.
2. The item URL host now links to the item URL in a new tab, with a symbol included to indicate so.
3. Both new links get underlined upon hovering to clarify their intent.

CC @huai-jie