### PR TITLE
refactor: use `deno task ok` task in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,5 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
 
-      - name: Verify formatting
-        run: deno fmt --check
-
-      - name: Run linter
-        run: deno lint
-
-      - name: Check license headers
-        run: deno task check:license --check
-
-      - name: Check types
-        run: deno check main.ts
-
-      - name: Run tests
-        run: deno task test
+      - name: Check formatting, linting, license headers, types and run tests
+        run: deno task ok


### PR DESCRIPTION
This ensures consistency between CI and local machines. My only concern is that we'll lose some debugability if something fails in CI. We'll have to see.