### PR TITLE
fix: `deno task check:license` permissions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
     "init:stripe": "deno run --allow-read --allow-env --allow-net tools/init_stripe.ts ",
     "start": "deno run --unstable -A --watch=static/,routes/ dev.ts",
     "test": "deno test -A",
-    "check:license": "deno run --allow-read tools/check_license.ts",
+    "check:license": "deno run --allow-read --allow-write tools/check_license.ts",
     "ok": "deno fmt --check && deno lint && deno task check:license --check && deno check main.ts && deno task test"
   },
   "importMap": "./import_map.json",


### PR DESCRIPTION
This change provides the necessary `--allow-write` permission to the `check:license` task, which is needed when not using the `--check` flag.