### PR TITLE
fix: Stripe checkout session type error

### DIFF
--- a/routes/account/upgrade.ts
+++ b/routes/account/upgrade.ts
@@ -28,6 +28,6 @@ export const handler: Handlers<null, AccountState> = {
       mode: "subscription",
     });
 
-    return redirect(url);
+    return redirect(url!);
   },
 };


### PR DESCRIPTION
According to the documentation, it's fine to use the non-null assertion error on `url` as the session is active in our case.

> The URL to the Checkout Session. Redirect customers to this URL to take them to Checkout. If you're using Custom Domains, the URL will use your subdomain. Otherwise, it'll use checkout.stripe.com. This value is only present when the session is active.

Fixes #179.