### PR TITLE
refactor: minor cleanup of `createServerSupabaseClient()`

### DIFF
--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -9,27 +9,24 @@ export type SupabaseClient = ReturnType<typeof createSupabaseClient>;
 
 export function createSupabaseClient(
   requestHeaders: Headers,
-  responseHeaders?: Headers,
+  responseHeaders: Headers,
 ) {
   return createServerSupabaseClient({
     supabaseUrl: Deno.env.get("SUPABASE_API_URL")!,
     supabaseKey: Deno.env.get("SUPABASE_ANON_KEY")!,
     getRequestHeader: (key) => requestHeaders.get(key) ?? undefined,
     getCookie: (name) => {
-      const cookie = getCookies(requestHeaders)[name] ?? "";
-      return decodeURIComponent(cookie);
+      const cookie = getCookies(requestHeaders)[name];
+      return cookie ? decodeURIComponent(cookie) : undefined;
     },
-    setCookie: (name, value, options) => {
-      if (responseHeaders) {
-        setCookie(responseHeaders, {
-          name,
-          value: encodeURIComponent(value),
-          ...options,
-          sameSite: "Lax",
-          httpOnly: false,
-        });
-      }
-    },
+    setCookie: (name, value, options) =>
+      setCookie(responseHeaders, {
+        name,
+        value: encodeURIComponent(value),
+        ...options,
+        sameSite: "Lax",
+        httpOnly: false,
+      }),
   });
 }
 


### PR DESCRIPTION
Since Supabase is now only used for authentication, the `responseHeaders` parameter is always provided. Hence, it's no longer optional. 