### PR TITLE
Append cookies in the response from supabase

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -38,6 +38,6 @@ export async function handler(
    * Note: ensure that a `new Response()` with a `location` header is used when performing server-side redirects.
    * Using `Response.redirect()` will throw as its headers are immutable.
    */
-  headers.forEach((value, key) => response.headers.set(key, value));
+  headers.forEach((value, key) => response.headers.append(key, value));
   return response;
 }


### PR DESCRIPTION
Supabase client sets two cookies during logout:

```
set-cookie supabase-auth-token=; SameSite=Lax; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT
set-cookie supabase-auth-token-code-verifier=; SameSite=Lax; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT
```

Previously, with `set` method the first cookie was not returned to the browser.

Fixes #153 