### PR TITLE
chore: add internal reset KV trigger

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -11,4 +11,13 @@ import manifest from "./fresh.gen.ts";
 import twindPlugin from "$fresh/plugins/twindv1.ts";
 import twindConfig from "./twind.config.ts";
 
+/**
+ * @todo Remove at v1. This is a quick way to reset Deno KV, as database changes are likely to occur and require reset.
+ */
+import { resetKv } from "./tools/reset_kv.ts";
+
+if (Deno.env.get("RESET_DENO_KV") === "1") {
+  await resetKv();
+}
+
 await start(manifest, { plugins: [twindPlugin(twindConfig)] });


### PR DESCRIPTION
This temporary switch triggers a Deno KV reset when `RESET_DENO_KV = "1"`. This will be removed once the KV has stabilised.