### PR TITLE
feat: page-number-based pagination

### DIFF
--- a/routes/api/stripe-webhooks.ts
+++ b/routes/api/stripe-webhooks.ts
@@ -2,7 +2,10 @@
 import type { Handlers } from "$fresh/server.ts";
 import { stripe } from "@/utils/payments.ts";
 import { Stripe } from "stripe";
-import { getUserByStripeCustomerId, setUserSubscription } from "@/utils/db.ts";
+import {
+  getUserByStripeCustomerId,
+  updateUserIsSubscribed,
+} from "@/utils/db.ts";
 
 const cryptoProvider = Stripe.createSubtleCryptoProvider();
 
@@ -38,13 +41,13 @@ export const handler: Handlers = {
       case "customer.subscription.created": {
         const user = await getUserByStripeCustomerId(customer);
         if (!user) return new Response(null, { status: 400 });
-        await setUserSubscription(user, true);
+        await updateUserIsSubscribed(user, true);
         return new Response(null, { status: 201 });
       }
       case "customer.subscription.deleted": {
         const user = await getUserByStripeCustomerId(customer);
         if (!user) return new Response(null, { status: 400 });
-        await setUserSubscription(user, false);
+        await updateUserIsSubscribed(user, false);
         return new Response(null, { status: 202 });
       }
       default: {

--- a/routes/api/vote.ts
+++ b/routes/api/vote.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { HandlerContext, Handlers, PageProps } from "$fresh/server.ts";
 import type { State } from "@/routes/_middleware.ts";
-import { createVote, deleteVote } from "@/utils/db.ts";
+import { createVote, deleteVote, getItemById } from "@/utils/db.ts";
 import { getUserBySessionId } from "@/utils/db.ts";
 
 async function sharedHandler(
@@ -18,10 +18,16 @@ async function sharedHandler(
     return new Response(null, { status: 400 });
   }
 
-  const user = await getUserBySessionId(ctx.state.sessionId);
+  const [item, user] = await Promise.all([
+    getItemById(itemId),
+    getUserBySessionId(ctx.state.sessionId),
+  ]);
 
-  if (!user) return new Response(null, { status: 400 });
-  const vote = { userId: user.id, itemId };
+  if (item === null || user === null) {
+    return new Response(null, { status: 404 });
+  }
+
+  const vote = { item, user };
   let status;
   switch (req.method) {
     case "DELETE":

--- a/routes/callback.ts
+++ b/routes/callback.ts
@@ -4,7 +4,7 @@ import { redirect } from "@/utils/http.ts";
 import {
   createUser,
   getUserById,
-  setUserSession,
+  setUserSessionId,
   type User,
 } from "@/utils/db.ts";
 import { stripe } from "@/utils/payments.ts";
@@ -51,7 +51,7 @@ export const handler: Handlers<any, State> = {
       };
       await createUser(userInit);
     } else {
-      await setUserSession(user, sessionId);
+      await setUserSessionId(user, sessionId);
     }
 
     const response = redirect("/");

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { Handlers, PageProps } from "$fresh/server.ts";
-import { INPUT_STYLES, SITE_WIDTH_STYLES } from "@/utils/constants.ts";
+import { SITE_WIDTH_STYLES } from "@/utils/constants.ts";
 import Layout from "@/components/Layout.tsx";
 import Head from "@/components/Head.tsx";
 import type { State } from "./_middleware.ts";
@@ -15,7 +15,7 @@ import {
   type User,
 } from "@/utils/db.ts";
 
-const PAGE_LENGTH = 2;
+const PAGE_LENGTH = 10;
 
 interface HomePageData extends State {
   itemsUsers: User[];

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -86,7 +86,7 @@ export default function HomePage(props: PageProps<HomePageData>) {
           {props.data.items.map((item, index) => (
             <ItemSummary
               item={item}
-              isVoted={props.data.areVoted?.[index]}
+              isVoted={props.data.areVoted[index]}
               user={props.data.itemsUsers[index]}
             />
           ))}

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,46 +1,83 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { Handlers, PageProps } from "$fresh/server.ts";
-import { SITE_WIDTH_STYLES } from "@/utils/constants.ts";
+import { INPUT_STYLES, SITE_WIDTH_STYLES } from "@/utils/constants.ts";
 import Layout from "@/components/Layout.tsx";
 import Head from "@/components/Head.tsx";
 import type { State } from "./_middleware.ts";
 import ItemSummary from "@/components/ItemSummary.tsx";
 import {
   compareScore,
-  getAllItems,
-  getUsersByIds,
-  getVotedItemsBySessionUser,
+  getAllItemsInPastWeek,
+  getAreVotedBySessionId,
+  getManyUsers,
   incrementVisitsPerDay,
   type Item,
   type User,
 } from "@/utils/db.ts";
 
+const PAGE_LENGTH = 2;
+
 interface HomePageData extends State {
-  users: User[];
+  itemsUsers: User[];
   items: Item[];
-  cursor?: string;
+  lastPage: number;
   areVoted: boolean[];
+}
+
+function calcPageNum(url: URL) {
+  return parseInt(url.searchParams.get("page") || "1");
+}
+
+function calcLastPage(total = 0, pageLength = PAGE_LENGTH): number {
+  return Math.ceil(total / pageLength);
 }
 
 export const handler: Handlers<HomePageData, State> = {
   async GET(req, ctx) {
-    /** @todo Add pagination functionality */
-    const start = new URL(req.url).searchParams.get("page") || undefined;
-    const { items, cursor } = await getAllItems({ limit: 10, cursor: start });
-    items.sort(compareScore);
-    const users = await getUsersByIds(items.map((item) => item.userId));
     await incrementVisitsPerDay(new Date());
-    const areVoted = await getVotedItemsBySessionUser(
+
+    const pageNum = calcPageNum(new URL(req.url));
+    const allItems = await getAllItemsInPastWeek();
+    const items = allItems
+      .toSorted(compareScore)
+      .slice((pageNum - 1) * PAGE_LENGTH, pageNum * PAGE_LENGTH);
+
+    const itemsUsers = await getManyUsers(items.map((item) => item.userId));
+
+    const areVoted = await getAreVotedBySessionId(
       items,
       ctx.state.sessionId,
     );
-    return ctx.render({ ...ctx.state, items, cursor, users, areVoted });
+    const lastPage = calcLastPage(allItems.length, PAGE_LENGTH);
+
+    return ctx.render({ ...ctx.state, items, itemsUsers, areVoted, lastPage });
   },
 };
 
+function PageSelector(props: { currentPage: number; lastPage: number }) {
+  return (
+    <div class="flex justify-center py-4 mx-auto">
+      <form class="inline-flex items-center gap-x-2">
+        <input
+          id="current_page"
+          class={`bg-white rounded rounded-lg outline-none w-full border-1 border-gray-300 hover:border-black transition duration-300 disabled:(opacity-50 cursor-not-allowed) rounded-md px-2 py-1`}
+          type="number"
+          name="page"
+          min="1"
+          max={props.lastPage}
+          value={props.currentPage}
+          // @ts-ignore: this is valid HTML
+          onchange="this.form.submit()"
+        />
+        <label for="current_page" class="whitespace-nowrap align-middle">
+          of {props.lastPage}
+        </label>
+      </form>
+    </div>
+  );
+}
+
 export default function HomePage(props: PageProps<HomePageData>) {
-  const nextPageUrl = new URL(props.url);
-  nextPageUrl.searchParams.set("page", props.data.cursor || "");
   return (
     <>
       <Head href={props.url.href} />
@@ -49,14 +86,15 @@ export default function HomePage(props: PageProps<HomePageData>) {
           {props.data.items.map((item, index) => (
             <ItemSummary
               item={item}
-              isVoted={props.data.areVoted[index]}
-              user={props.data.users[index]}
+              isVoted={props.data.areVoted?.[index]}
+              user={props.data.itemsUsers[index]}
             />
           ))}
-          {props.data?.cursor && (
-            <div class="mt-4 text-gray-500">
-              <a href={nextPageUrl.toString()}>More</a>
-            </div>
+          {props.data.lastPage > 1 && (
+            <PageSelector
+              currentPage={calcPageNum(props.url)}
+              lastPage={props.data.lastPage}
+            />
           )}
         </div>
       </Layout>

--- a/routes/item/[id].tsx
+++ b/routes/item/[id].tsx
@@ -14,10 +14,10 @@ import {
   createComment,
   getCommentsByItem,
   getItemById,
+  getManyUsers,
   getUserById,
   getUserBySessionId,
-  getUsersByIds,
-  getVotedItemIdsByUser,
+  getVotedItemsByUser,
   type Item,
   type User,
 } from "@/utils/db.ts";
@@ -43,7 +43,7 @@ export const handler: Handlers<ItemPageData, State> = {
     }
 
     const comments = await getCommentsByItem(id);
-    const commentsUsers = await getUsersByIds(
+    const commentsUsers = await getManyUsers(
       comments.map((comment) => comment.userId),
     );
     const user = await getUserById(item.userId);
@@ -51,7 +51,11 @@ export const handler: Handlers<ItemPageData, State> = {
     let votedItemIds: string[] = [];
     if (ctx.state.sessionId) {
       const sessionUser = await getUserBySessionId(ctx.state.sessionId);
-      votedItemIds = await getVotedItemIdsByUser(sessionUser!.id);
+
+      if (sessionUser) {
+        const votedItems = await getVotedItemsByUser(sessionUser?.id);
+        votedItemIds = votedItems.map((item) => item.id);
+      }
     }
 
     const isVoted = votedItemIds.includes(id);

--- a/routes/user/[username].tsx
+++ b/routes/user/[username].tsx
@@ -8,9 +8,9 @@ import { SITE_WIDTH_STYLES } from "@/utils/constants.ts";
 import ItemSummary from "@/components/ItemSummary.tsx";
 import {
   compareScore,
+  getAreVotedBySessionId,
   getItemsByUserId,
   getUserByLogin,
-  getVotedItemsBySessionUser,
   type Item,
   type User,
 } from "@/utils/db.ts";
@@ -33,7 +33,7 @@ export const handler: Handlers<UserData, State> = {
 
     const items = await getItemsByUserId(user.id);
     items.sort(compareScore);
-    const areVoted = await getVotedItemsBySessionUser(
+    const areVoted = await getAreVotedBySessionId(
       items,
       ctx.state.sessionId,
     );

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -8,8 +8,8 @@ import {
   getVisitsPerDay,
   incrementVisitsPerDay,
   kv,
-  setUserSession,
-  setUserSubscription,
+  setUserSessionId,
+  updateUserIsSubscribed,
   type User,
 } from "./db.ts";
 import { assertEquals } from "std/testing/asserts.ts";
@@ -67,7 +67,7 @@ Deno.test("[db] user", async () => {
   assertEquals(await getUserBySessionId(user.sessionId), user);
   assertEquals(await getUserByStripeCustomerId(user.stripeCustomerId), user);
 
-  await setUserSubscription(user, true);
+  await updateUserIsSubscribed(user, true);
   user = { ...user, isSubscribed: true };
   assertEquals(await getUserById(user.id), user);
   assertEquals(await getUserByLogin(user.login), user);
@@ -75,7 +75,7 @@ Deno.test("[db] user", async () => {
   assertEquals(await getUserByStripeCustomerId(user.stripeCustomerId), user);
 
   const sessionId = crypto.randomUUID();
-  await setUserSession(user, sessionId);
+  await setUserSessionId(user, sessionId);
   user = { ...user, sessionId };
   assertEquals(await getUserById(user.id), user);
   assertEquals(await getUserByLogin(user.login), user);


### PR DESCRIPTION
This PR:
1. Introduces page-number-based pagination to the homepage.
2. Refactors much of the database-related code to be more straightforward.
3. Changes the homepage to show only the items posted in the last week.
4. Supercedes #236
5. Moves functionality closer to #211
6. Closes #233
7. Closes #231

Note: once merged, these same changes can be made to paginate item and user pages.

Please feel free to review, @brunocorrea23 and @huai-jie.