### PR TITLE
feat: adding new stats

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -10,7 +10,7 @@ import {
   getAllItemsInPastWeek,
   getAreVotedBySessionId,
   getManyUsers,
-  incrementVisitsPerDay,
+  incrementAnalyticsMetricPerDay,
   type Item,
   type User,
 } from "@/utils/db.ts";
@@ -34,7 +34,7 @@ function calcLastPage(total = 0, pageLength = PAGE_LENGTH): number {
 
 export const handler: Handlers<HomePageData, State> = {
   async GET(req, ctx) {
-    await incrementVisitsPerDay(new Date());
+    await incrementAnalyticsMetricPerDay("visits_count", new Date());
 
     const pageNum = calcPageNum(new URL(req.url));
     const allItems = await getAllItemsInPastWeek();

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -81,7 +81,7 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
             {props.data.metricsByDay.map((metric, index) => (
               <LineChart
                 title={props.data.metricsTitles[index]}
-                x={props.data.dates!.map((date) =>
+                x={metric.dates!.map((date) =>
                   new Date(date).toLocaleDateString("en-us", {
                     year: "numeric",
                     month: "short",

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -41,33 +41,38 @@ function LineChart(
   props: { title: string; x: string[]; y: number[] },
 ) {
   return (
-    <>
+    <div class="py-4">
       <h3 class="py-4 text-2xl font-bold">{props.title}</h3>
-      <Chart
-        type="line"
-        options={{
-          plugins: {
-            legend: { display: false },
-          },
-          scales: {
-            y: { grid: { display: false } },
-            x: { grid: { display: false } },
-          },
-        }}
-        data={{
-          labels: props.x,
-          datasets: [{
-            label: props.title,
-            data: props.y,
-            borderColor: ChartColors.Blue,
-            backgroundColor: ChartColors.Blue,
-            borderWidth: 3,
-            cubicInterpolationMode: "monotone",
-            tension: 0.4,
-          }],
-        }}
-      />
-    </>
+      <div class="relative">
+        <Chart
+          width={550}
+          height={300}
+          type="line"
+          options={{
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false },
+            },
+            scales: {
+              y: { grid: { display: false } },
+              x: { grid: { display: false } },
+            },
+          }}
+          data={{
+            labels: props.x,
+            datasets: [{
+              label: props.title,
+              data: props.y,
+              borderColor: ChartColors.Blue,
+              backgroundColor: ChartColors.Blue,
+              borderWidth: 3,
+              cubicInterpolationMode: "monotone",
+              tension: 0.4,
+            }],
+          }}
+        />
+      </div>
+    </div>
   );
 }
 
@@ -77,20 +82,22 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
       <Head title="Stats" href={props.url.href} />
       <Layout session={props.data.sessionId}>
         <div class={`${SITE_WIDTH_STYLES} flex-1 px-4`}>
-          <div class="p-4 mx-auto max-w-screen-md">
-            {props.data.metricsByDay.map((metric, index) => (
-              <LineChart
-                title={props.data.metricsTitles[index]}
-                x={metric.dates!.map((date) =>
-                  new Date(date).toLocaleDateString("en-us", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  })
-                )}
-                y={metric.metricsValue!}
-              />
-            ))}
+          <div class="p-4">
+            <div class="grid grid-cols-2 gap-4">
+              {props.data.metricsByDay.map((metric, index) => (
+                <LineChart
+                  title={props.data.metricsTitles[index]}
+                  x={metric.dates!.map((date) =>
+                    new Date(date).toLocaleDateString("en-us", {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                    })
+                  )}
+                  y={metric.metricsValue!}
+                />
+              ))}
+            </div>
           </div>
         </div>
       </Layout>

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -43,35 +43,33 @@ function LineChart(
   return (
     <div class="py-4">
       <h3 class="py-4 text-2xl font-bold">{props.title}</h3>
-      <div class="relative">
-        <Chart
-          width={550}
-          height={300}
-          type="line"
-          options={{
-            maintainAspectRatio: false,
-            plugins: {
-              legend: { display: false },
-            },
-            scales: {
-              y: { grid: { display: false } },
-              x: { grid: { display: false } },
-            },
-          }}
-          data={{
-            labels: props.x,
-            datasets: [{
-              label: props.title,
-              data: props.y,
-              borderColor: ChartColors.Blue,
-              backgroundColor: ChartColors.Blue,
-              borderWidth: 3,
-              cubicInterpolationMode: "monotone",
-              tension: 0.4,
-            }],
-          }}
-        />
-      </div>
+      <Chart
+        width={550}
+        height={300}
+        type="line"
+        options={{
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+          },
+          scales: {
+            y: { grid: { display: false } },
+            x: { grid: { display: false } },
+          },
+        }}
+        data={{
+          labels: props.x,
+          datasets: [{
+            label: props.title,
+            data: props.y,
+            borderColor: ChartColors.Blue,
+            backgroundColor: ChartColors.Blue,
+            borderWidth: 3,
+            cubicInterpolationMode: "monotone",
+            tension: 0.4,
+          }],
+        }}
+      />
     </div>
   );
 }
@@ -82,22 +80,20 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
       <Head title="Stats" href={props.url.href} />
       <Layout session={props.data.sessionId}>
         <div class={`${SITE_WIDTH_STYLES} flex-1 px-4`}>
-          <div class="p-4">
-            <div class="grid grid-cols-2 gap-4">
-              {props.data.metricsByDay.map((metric, index) => (
-                <LineChart
-                  title={props.data.metricsTitles[index]}
-                  x={metric.dates!.map((date) =>
-                    new Date(date).toLocaleDateString("en-us", {
-                      year: "numeric",
-                      month: "short",
-                      day: "numeric",
-                    })
-                  )}
-                  y={metric.metricsValue!}
-                />
-              ))}
-            </div>
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {props.data.metricsByDay.map((metric, index) => (
+              <LineChart
+                title={props.data.metricsTitles[index]}
+                x={metric.dates!.map((date) =>
+                  new Date(date).toLocaleDateString("en-us", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })
+                )}
+                y={metric.metricsValue!}
+              />
+            ))}
           </div>
         </div>
       </Layout>

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -4,23 +4,45 @@ import { SITE_WIDTH_STYLES } from "@/utils/constants.ts";
 import Layout from "@/components/Layout.tsx";
 import Head from "@/components/Head.tsx";
 import type { State } from "./_middleware.ts";
-import { getAllVisitsPerDay } from "@/utils/db.ts";
+import { getAnalyticsMetricsPerDay } from "@/utils/db.ts";
 import { Chart } from "fresh_charts/mod.ts";
 import { ChartColors } from "fresh_charts/utils.ts";
 
+interface AnalyticsByDay {
+  metricsValue: number[];
+  dates: string[];
+}
+
 interface StatsPageData extends State {
-  visits?: number[];
-  dates?: string[];
+  visitsCountByDay: AnalyticsByDay;
+  userCountByDay: AnalyticsByDay;
+  itemsCountByDay: AnalyticsByDay;
+  votesCountByDay: AnalyticsByDay;
 }
 
 export const handler: Handlers<StatsPageData, State> = {
   async GET(_, ctx) {
     const daysBefore = 30;
-    const { visits, dates } = await getAllVisitsPerDay({
+    const visitsCountByDay = await getAnalyticsMetricsPerDay("visits_count", {
+      limit: daysBefore,
+    });
+    const userCountByDay = await getAnalyticsMetricsPerDay("users_count", {
+      limit: daysBefore,
+    });
+    const itemsCountByDay = await getAnalyticsMetricsPerDay("items_count", {
+      limit: daysBefore,
+    });
+    const votesCountByDay = await getAnalyticsMetricsPerDay("votes_count", {
       limit: daysBefore,
     });
 
-    return ctx.render({ ...ctx.state, visits, dates });
+    return ctx.render({
+      ...ctx.state,
+      visitsCountByDay,
+      userCountByDay,
+      itemsCountByDay,
+      votesCountByDay,
+    });
   },
 };
 
@@ -67,8 +89,23 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
           <div class="p-4 mx-auto max-w-screen-md">
             <LineChart
               title="Visits"
-              x={props.data.dates!}
-              y={props.data.visits!}
+              x={props.data.visitsCountByDay.dates!}
+              y={props.data.visitsCountByDay.metricsValue!}
+            />
+            <LineChart
+              title="New Users"
+              x={props.data.userCountByDay.dates!}
+              y={props.data.userCountByDay.metricsValue!}
+            />
+            <LineChart
+              title="New Items"
+              x={props.data.itemsCountByDay.dates!}
+              y={props.data.itemsCountByDay.metricsValue!}
+            />
+            <LineChart
+              title="New Votes"
+              x={props.data.votesCountByDay.dates!}
+              y={props.data.votesCountByDay.metricsValue!}
             />
           </div>
         </div>

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -58,6 +58,8 @@ export async function createItem(initItem: InitItem) {
 
   if (!res.ok) throw new Error(`Failed to set item: ${item}`);
 
+  await incrementAnalyticsMetricPerDay("items_count", new Date());
+
   return item;
 }
 
@@ -165,6 +167,8 @@ export async function createVote(vote: Vote) {
 
   if (!res.ok) throw new Error(`Failed to set vote: ${vote}`);
 
+  await incrementAnalyticsMetricPerDay("votes_count", new Date());
+
   return vote;
 }
 
@@ -251,6 +255,8 @@ export async function createUser(initUser: InitUser) {
 
   if (!res.ok) throw new Error(`Failed to create user: ${user}`);
 
+  await incrementAnalyticsMetricPerDay("users_count", new Date());
+
   return user;
 }
 
@@ -317,7 +323,37 @@ export async function getManyUsers(ids: string[]) {
   return res.map((entry) => entry.value!);
 }
 
-// Visit
+export async function getAreVotedBySessionId(
+  items: Item[],
+  sessionId?: string,
+) {
+  if (!sessionId) return [];
+  const sessionUser = await getUserBySessionId(sessionId);
+  if (!sessionUser) return [];
+  const votedItems = await getVotedItemsByUser(sessionUser.id);
+  const votedItemIds = votedItems.map((item) => item.id);
+  return items.map((item) => votedItemIds.includes(item.id));
+}
+
+export function compareScore(a: Item, b: Item) {
+  return Number(b.score) - Number(a.score);
+}
+
+// Analytics
+export async function incrementAnalyticsMetricPerDay(
+  metric: string,
+  date: Date,
+) {
+  // convert to universal timezone (UTC)
+  const metricKey = [
+    metric,
+    `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}`,
+  ];
+  await kv.atomic()
+    .sum(metricKey, 1n)
+    .commit();
+}
+
 export async function incrementVisitsPerDay(date: Date) {
   // convert to universal timezone (UTC)
   const visitsKey = [
@@ -336,16 +372,18 @@ export async function getVisitsPerDay(date: Date) {
   ]);
 }
 
-export async function getAreVotedBySessionId(
-  items: Item[],
-  sessionId?: string,
+export async function getAnalyticsMetricsPerDay(
+  metric: string,
+  options?: Deno.KvListOptions,
 ) {
-  if (!sessionId) return [];
-  const sessionUser = await getUserBySessionId(sessionId);
-  if (!sessionUser) return [];
-  const votedItems = await getVotedItemsByUser(sessionUser.id);
-  const votedItemIds = votedItems.map((item) => item.id);
-  return items.map((item) => votedItemIds.includes(item.id));
+  const iter = await kv.list<bigint>({ prefix: [metric] }, options);
+  const metricsValue = [];
+  const dates = [];
+  for await (const res of iter) {
+    metricsValue.push(Number(res.value));
+    dates.push(String(res.key[1]));
+  }
+  return { metricsValue, dates };
 }
 
 export async function getAllVisitsPerDay(options?: Deno.KvListOptions) {
@@ -357,8 +395,4 @@ export async function getAllVisitsPerDay(options?: Deno.KvListOptions) {
     dates.push(String(res.key[1]));
   }
   return { visits, dates };
-}
-
-export function compareScore(a: Item, b: Item) {
-  return Number(b.score) - Number(a.score);
 }

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -344,7 +344,7 @@ export async function incrementAnalyticsMetricPerDay(
   metric: string,
   date: Date,
 ) {
-  // convert to universal timezone (UTC)
+  // convert to ISO format that is zero UTC offset
   const metricKey = [
     metric,
     `${date.toISOString().split("T")[0]}`,

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -386,6 +386,17 @@ export async function getAnalyticsMetricsPerDay(
   return { metricsValue, dates };
 }
 
+export async function getManyAnalyticsMetricsPerDay(
+  metrics: string[],
+  options?: Deno.KvListOptions,
+) {
+  const analyticsByDay = await Promise.all(
+    metrics.map((metric) => getAnalyticsMetricsPerDay(metric, options)),
+  );
+
+  return analyticsByDay;
+}
+
 export async function getAllVisitsPerDay(options?: Deno.KvListOptions) {
   const iter = await kv.list<bigint>({ prefix: ["visits"] }, options);
   const visits = [];

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -347,7 +347,7 @@ export async function incrementAnalyticsMetricPerDay(
   // convert to universal timezone (UTC)
   const metricKey = [
     metric,
-    `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}`,
+    `${date.toISOString().split("T")[0]}`,
   ];
   await kv.atomic()
     .sum(metricKey, 1n)


### PR DESCRIPTION
- Refactored the code a little bit to make it very easy to add new stats
- Added missing stats from #202 (New items per day, New votes per day, New users per day)
- Changed the kv key for the 'visits per day' stats. Means we would lose the data we had before if there is no migration.
- UI for the /stats page needs some love
- Does not address #240 as it should be solved in #241 