### PR TITLE
feat: redirect to referer page after login

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -2,6 +2,7 @@
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
 import { walk } from "std/fs/walk.ts";
 import { getSessionId } from "@/utils/deno_kv_oauth.ts";
+import { setCookie } from "std/http/cookie.ts";
 
 export interface State {
   sessionId?: string;
@@ -25,5 +26,15 @@ export async function handler(
 
   ctx.state.sessionId = getSessionId(req.headers);
 
-  return await ctx.next();
+  const res = await ctx.next();
+
+  if (ctx.destination === "route" && pathname === "/login") {
+    setCookie(res.headers, {
+      name: "redirectUrl",
+      value: req.headers.get("referer")!,
+      path: "/",
+    });
+  }
+
+  return res;
 }

--- a/routes/callback.ts
+++ b/routes/callback.ts
@@ -11,6 +11,7 @@ import { stripe } from "@/utils/payments.ts";
 import { State } from "./_middleware.ts";
 import { getAccessToken, setCallbackHeaders } from "@/utils/deno_kv_oauth.ts";
 import { oauth2Client } from "@/utils/oauth2_client.ts";
+import { deleteCookie, getCookies } from "std/http/cookie.ts";
 
 interface GitHubUser {
   id: number;
@@ -53,8 +54,9 @@ export const handler: Handlers<any, State> = {
     } else {
       await setUserSessionId(user, sessionId);
     }
-
-    const response = redirect("/");
+    const { redirectUrl } = getCookies(req.headers);
+    const response = redirect(redirectUrl);
+    deleteCookie(response.headers, "redirectUrl");
     setCallbackHeaders(response.headers, sessionId);
     return response;
   },


### PR DESCRIPTION
### i.e 
Clicking on the `comment` button on an item's page initiates the `login` process. It would be beneficial if, after logging in, users could be redirected back to the same item page.