### PR TITLE
fix: Stripe types and checks

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -6,7 +6,7 @@ import {
   SITE_WIDTH_STYLES,
 } from "@/utils/constants.ts";
 import Logo from "./Logo.tsx";
-import { stripe } from "../utils/payments.ts";
+import { stripe } from "@/utils/payments.ts";
 import { Discord, GitHub } from "./Icons.tsx";
 
 interface NavProps extends JSX.HTMLAttributes<HTMLElement> {

--- a/deno.json
+++ b/deno.json
@@ -26,7 +26,7 @@
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.2.3",
     "twind-preset-tailwind/": "https://esm.sh/@twind/preset-tailwind@1.1.4/",
     "std/": "https://deno.land/std@0.188.0/",
-    "stripe": "https://esm.sh/stripe@12.6.0",
+    "stripe": "./stripe.ts",
     "feed": "https://esm.sh/feed@4.2.2",
     "fresh_charts/": "https://deno.land/x/fresh_charts@0.2.2/",
     "kv_oauth": "https://deno.land/x/deno_kv_oauth@v0.2.5/mod.ts",

--- a/routes/account/manage.ts
+++ b/routes/account/manage.ts
@@ -7,7 +7,9 @@ import { redirect } from "@/utils/redirect.ts";
 // deno-lint-ignore no-explicit-any
 export const handler: Handlers<any, AccountState> = {
   async GET(req, ctx) {
-    if (stripe === undefined) return ctx.renderNotFound();
+    if (stripe === undefined || ctx.state.user.stripeCustomerId === undefined) {
+      return ctx.renderNotFound();
+    }
 
     const { url } = await stripe.billingPortal.sessions.create({
       customer: ctx.state.user.stripeCustomerId,

--- a/routes/api/stripe-webhooks.ts
+++ b/routes/api/stripe-webhooks.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { Handlers } from "$fresh/server.ts";
 import { stripe } from "@/utils/payments.ts";
-import { Stripe } from "stripe";
+import Stripe from "stripe";
 import { getUserByStripeCustomer, updateUser } from "@/utils/db.ts";
 
 const cryptoProvider = Stripe.createSubtleCryptoProvider();

--- a/routes/pricing.tsx
+++ b/routes/pricing.tsx
@@ -3,7 +3,7 @@ import type { Handlers, PageProps } from "$fresh/server.ts";
 import Head from "@/components/Head.tsx";
 import type { State } from "@/routes/_middleware.ts";
 import { BUTTON_STYLES } from "@/utils/constants.ts";
-import { formatAmountForDisplay, stripe } from "@/utils/payments.ts";
+import { StripProductWithPrice, formatAmountForDisplay, isProductWithPrice, stripe } from "@/utils/payments.ts";
 import Stripe from "stripe";
 import { ComponentChild } from "preact";
 import { getUserBySession, type User } from "@/utils/db.ts";
@@ -14,11 +14,11 @@ interface PricingPageData extends State {
 }
 
 function comparePrices(
-  productA: Stripe.Product,
-  productB: Stripe.Product,
+  productA: StripProductWithPrice,
+  productB: StripProductWithPrice,
 ) {
-  return ((productA.default_price as Stripe.Price).unit_amount || 0) -
-    ((productB.default_price as Stripe.Price).unit_amount || 0);
+  return (productA.default_price.unit_amount || 0) -
+    (productB.default_price.unit_amount || 0);
 }
 
 export const handler: Handlers<PricingPageData, State> = {
@@ -29,7 +29,14 @@ export const handler: Handlers<PricingPageData, State> = {
       expand: ["data.default_price"],
       active: true,
     });
-    const products = data.sort(comparePrices);
+    
+    const productsWithPrice = data.filter(isProductWithPrice);
+    
+    if (productsWithPrice.length !== data.length) {
+      throw new Error("Not all products have a default price. Please run the `deno task init:stripe` as the README instructs.");
+    }
+
+    const products = productsWithPrice.sort(comparePrices);
 
     const user = ctx.state.sessionId
       ? await getUserBySession(ctx.state.sessionId)

--- a/routes/pricing.tsx
+++ b/routes/pricing.tsx
@@ -3,7 +3,12 @@ import type { Handlers, PageProps } from "$fresh/server.ts";
 import Head from "@/components/Head.tsx";
 import type { State } from "@/routes/_middleware.ts";
 import { BUTTON_STYLES } from "@/utils/constants.ts";
-import { StripProductWithPrice, formatAmountForDisplay, isProductWithPrice, stripe } from "@/utils/payments.ts";
+import {
+  formatAmountForDisplay,
+  isProductWithPrice,
+  stripe,
+  StripProductWithPrice,
+} from "@/utils/payments.ts";
 import Stripe from "stripe";
 import { ComponentChild } from "preact";
 import { getUserBySession, type User } from "@/utils/db.ts";
@@ -29,11 +34,13 @@ export const handler: Handlers<PricingPageData, State> = {
       expand: ["data.default_price"],
       active: true,
     });
-    
+
     const productsWithPrice = data.filter(isProductWithPrice);
-    
+
     if (productsWithPrice.length !== data.length) {
-      throw new Error("Not all products have a default price. Please run the `deno task init:stripe` as the README instructs.");
+      throw new Error(
+        "Not all products have a default price. Please run the `deno task init:stripe` as the README instructs.",
+      );
     }
 
     const products = productsWithPrice.sort(comparePrices);

--- a/stripe.ts
+++ b/stripe.ts
@@ -1,5 +1,7 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+
 // Default types for Stripe don't yet work: https://github.com/stripe-samples/stripe-node-deno-samples/issues/2
 // @deno-types="npm:stripe@12.6.0"
 import Stripe from "https://esm.sh/stripe@12.6.0";
 
-export default Stripe
+export default Stripe;

--- a/stripe.ts
+++ b/stripe.ts
@@ -1,0 +1,5 @@
+// Default types for Stripe don't yet work: https://github.com/stripe-samples/stripe-node-deno-samples/issues/2
+// @deno-types="npm:stripe@12.6.0"
+import Stripe from "https://esm.sh/stripe@12.6.0";
+
+export default Stripe

--- a/utils/payments.ts
+++ b/utils/payments.ts
@@ -26,7 +26,7 @@ if (stripe) {
 
 /**
  * We assume that the product has a default price.
- * The offical types allow for the default_price to be `undefined | null | string`
+ * The official types allow for the default_price to be `undefined | null | string`
  */
 export type StripProductWithPrice = Stripe.Product & {
   default_price: Stripe.Price;
@@ -37,9 +37,8 @@ export function isProductWithPrice(
 ): product is StripProductWithPrice {
   return product.default_price !== undefined &&
     product.default_price !== null &&
-    typeof product.default_price !== "string"
+    typeof product.default_price !== "string";
 }
-
 
 export function formatAmountForDisplay(
   amount: number,

--- a/utils/payments.ts
+++ b/utils/payments.ts
@@ -1,7 +1,4 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-//
-// Default types for Stripe don't yet work: https://github.com/stripe-samples/stripe-node-deno-samples/issues/2
-// @deno-types="npm:stripe"
 import Stripe from "stripe";
 
 const STRIPE_SECRET_KEY = Deno.env.get("STRIPE_SECRET_KEY");

--- a/utils/payments.ts
+++ b/utils/payments.ts
@@ -1,4 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
+//
+// Default types for Stripe don't yet work: https://github.com/stripe-samples/stripe-node-deno-samples/issues/2
+// @deno-types="npm:stripe"
 import Stripe from "stripe";
 
 const STRIPE_SECRET_KEY = Deno.env.get("STRIPE_SECRET_KEY");
@@ -23,6 +26,23 @@ if (stripe) {
     "`STRIPE_SECRET_KEY` environment variable is not defined. Stripe is disabled.",
   );
 }
+
+/**
+ * We assume that the product has a default price.
+ * The offical types allow for the default_price to be `undefined | null | string`
+ */
+export type StripProductWithPrice = Stripe.Product & {
+  default_price: Stripe.Price;
+};
+
+export function isProductWithPrice(
+  product: Stripe.Product,
+): product is StripProductWithPrice {
+  return product.default_price !== undefined &&
+    product.default_price !== null &&
+    typeof product.default_price !== "string"
+}
+
 
 export function formatAmountForDisplay(
   amount: number,


### PR DESCRIPTION
Fixes https://github.com/denoland/saaskit/issues/261

## Adding types

I started by adding
```
// @deno-types="npm:stripe"
```
just above the `Stripe` import.
This is based on https://deno.com/manual@v1.34.0/advanced/typescript/types#providing-types-when-importing

This is not the best solution, but currently there's an issue with having types for Stripe in Deno: 
https://github.com/stripe-samples/stripe-node-deno-samples/issues/2

## Covering all possibilities
After the initial error was fixed, I was receiving a different error, also caused by type assertions, so I had to change
```
pricePerInterval={toPricePerInterval(
                product.default_price as Stripe.Price,
              )}
```
and handle all cases

## Testing
1. `git clone ...`
2. `deno task start`
3. access http://localhost:8000/pricing
4. you shouldn't see a 500 error



          
<img width="1481" alt="Screenshot 2023-06-18 at 02 28 30" src="https://github.com/denoland/saaskit/assets/4076804/3380e1a9-5808-4125-ae60-9e5c9bfccaad">


## PS
`defaultPrice.recurring?.interval` already has a defined type, but I wasn't sure what's the correct way to import it in Deno. I left it as string since it's not a critical part of the app, it's used just for displaying text. So it's not a high-concern at the moment.


<img width="773" alt="Screenshot 2023-06-18 at 02 29 37" src="https://github.com/denoland/saaskit/assets/4076804/b50d1d77-e324-40a2-980e-58e8561216a9">
