### PR TITLE
fix: avatar size

### DIFF
--- a/components/UserPostedAt.tsx
+++ b/components/UserPostedAt.tsx
@@ -9,7 +9,7 @@ export default function UserPostedAt(
     <p class="text-gray-500">
       <img
         //adding the extra parameter to resize the github avatar
-        src={props.user.avatarUrl + "&s=24"}
+        src={props.user.avatarUrl + "&s=36"}
         alt={props.user.login}
         crossOrigin="anonymous"
         class="h-6 w-auto rounded-full aspect-square inline-block mr-1 align-bottom"


### PR DESCRIPTION
after the previous PR #277 , lighthouse started complaining about low resolution of the avatar images. I'm increasing the size from 24 to 36 and it should solve this issue.

<img width="787" alt="Screenshot 2023-06-21 at 02 42 22" src="https://github.com/denoland/saaskit/assets/8139585/26a3da27-f943-4312-bd8f-4b5d70c26a55">
