### PR TITLE
refactor: items logic in KV

### DIFF
--- a/routes/api/vote.ts
+++ b/routes/api/vote.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { HandlerContext, Handlers, PageProps } from "$fresh/server.ts";
 import type { State } from "@/routes/_middleware.ts";
-import { createVote, deleteVote, getItemById } from "@/utils/db.ts";
+import { createVote, deleteVote, getItem } from "@/utils/db.ts";
 import { getUserBySessionId } from "@/utils/db.ts";
 
 async function sharedHandler(
@@ -19,7 +19,7 @@ async function sharedHandler(
   }
 
   const [item, user] = await Promise.all([
-    getItemById(itemId),
+    getItem(itemId),
     getUserBySessionId(ctx.state.sessionId),
   ]);
 

--- a/routes/item/[id].tsx
+++ b/routes/item/[id].tsx
@@ -15,7 +15,7 @@ import {
   createComment,
   getAreVotedBySessionId,
   getCommentsByItem,
-  getItemById,
+  getItem,
   getManyUsers,
   getUserById,
   getUserBySessionId,
@@ -42,7 +42,7 @@ export const handler: Handlers<ItemPageData, State> = {
     const url = new URL(req.url);
     const pageNum = calcPageNum(url);
 
-    const item = await getItemById(id);
+    const item = await getItem(id);
     if (item === null) {
       return ctx.renderNotFound();
     }

--- a/routes/submit.tsx
+++ b/routes/submit.tsx
@@ -4,11 +4,11 @@ import Head from "@/components/Head.tsx";
 import { BUTTON_STYLES, INPUT_STYLES } from "@/utils/constants.ts";
 import type { State } from "@/routes/_middleware.ts";
 import {
+  createItem,
   getUserBySessionId,
   incrementAnalyticsMetricPerDay,
   type Item,
   newItemProps,
-  setItem,
 } from "@/utils/db.ts";
 import { redirect } from "@/utils/redirect.ts";
 import { redirectToLogin } from "@/utils/redirect.ts";
@@ -50,7 +50,7 @@ export const handler: Handlers<State, State> = {
       url,
       ...newItemProps(),
     };
-    await setItem(item);
+    await createItem(item);
     await incrementAnalyticsMetricPerDay("items_count", new Date());
 
     return redirect(`/item/${item!.id}`);

--- a/routes/submit.tsx
+++ b/routes/submit.tsx
@@ -3,7 +3,13 @@ import type { Handlers, PageProps } from "$fresh/server.ts";
 import Head from "@/components/Head.tsx";
 import { BUTTON_STYLES, INPUT_STYLES } from "@/utils/constants.ts";
 import type { State } from "@/routes/_middleware.ts";
-import { createItem, getUserBySessionId } from "@/utils/db.ts";
+import {
+  getUserBySessionId,
+  incrementAnalyticsMetricPerDay,
+  type Item,
+  newItemProps,
+  setItem,
+} from "@/utils/db.ts";
 import { redirect } from "@/utils/redirect.ts";
 import { redirectToLogin } from "@/utils/redirect.ts";
 
@@ -38,11 +44,14 @@ export const handler: Handlers<State, State> = {
 
     if (!user) return new Response(null, { status: 400 });
 
-    const item = await createItem({
+    const item: Item = {
       userId: user.id,
       title,
       url,
-    });
+      ...newItemProps(),
+    };
+    await setItem(item);
+    await incrementAnalyticsMetricPerDay("items_count", new Date());
 
     return redirect(`/item/${item!.id}`);
   },

--- a/routes/user/[username].tsx
+++ b/routes/user/[username].tsx
@@ -8,7 +8,7 @@ import ItemSummary from "@/components/ItemSummary.tsx";
 import {
   compareScore,
   getAreVotedBySessionId,
-  getItemsByUserId,
+  getItemsByUser,
   getUserByLogin,
   type Item,
   type User,
@@ -30,7 +30,7 @@ export const handler: Handlers<UserData, State> = {
       return ctx.renderNotFound();
     }
 
-    const items = await getItemsByUserId(user.id);
+    const items = await getItemsByUser(user.id);
     items.sort(compareScore);
     const areVoted = await getAreVotedBySessionId(
       items,

--- a/tools/seed_submissions.ts
+++ b/tools/seed_submissions.ts
@@ -1,6 +1,12 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 // Description: Seeds the kv db with Hacker News stories
-import { createItem, createUser, type Item, kv } from "@/utils/db.ts";
+import {
+  createUser,
+  incrementAnalyticsMetricPerDay,
+  type Item,
+  newItemProps,
+  setItem,
+} from "@/utils/db.ts";
 
 // Reference: https://github.com/HackerNews/API
 const API_BASE_URL = `https://hacker-news.firebaseio.com/v0`;
@@ -54,18 +60,10 @@ async function fetchTopStories(limit = 10) {
   return stories;
 }
 
-async function createItemWithScore(item: Item) {
-  const res = await createItem(item);
-  return await kv.set(["items", res!.id], {
-    ...res,
-    score: item.score,
-    createdAt: item.createdAt,
-  });
-}
-
 async function seedSubmissions(stories: Story[]) {
   const items = stories.map(({ by: userId, title, url, score, time }) => {
     return {
+      ...newItemProps(),
       userId,
       title,
       url,
@@ -74,7 +72,14 @@ async function seedSubmissions(stories: Story[]) {
     } as Item;
   }).filter(({ url }) => url);
   for (const batch of batchify(items)) {
-    await Promise.all(batch.map((item) => createItemWithScore(item)));
+    await Promise.all(
+      batch.map((item) =>
+        Promise.all([
+          setItem(item),
+          incrementAnalyticsMetricPerDay("items_count", new Date()),
+        ])
+      ),
+    );
   }
   return items;
 }

--- a/tools/seed_submissions.ts
+++ b/tools/seed_submissions.ts
@@ -1,11 +1,11 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 // Description: Seeds the kv db with Hacker News stories
 import {
+  createItem,
   createUser,
   incrementAnalyticsMetricPerDay,
   type Item,
   newItemProps,
-  setItem,
 } from "@/utils/db.ts";
 
 // Reference: https://github.com/HackerNews/API
@@ -75,7 +75,7 @@ async function seedSubmissions(stories: Story[]) {
     await Promise.all(
       batch.map((item) =>
         Promise.all([
-          setItem(item),
+          createItem(item),
           incrementAnalyticsMetricPerDay("items_count", new Date()),
         ])
       ),

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -83,20 +83,6 @@ export async function createItem(item: Item) {
   if (!res.ok) throw new Error(`Failed to create item: ${item}`);
 }
 
-export async function deleteItem(item: Item) {
-  const itemsKey = ["items", item.id];
-  const itemsByTimeKey = ["items_by_time", item.createdAt.getTime(), item.id];
-  const itemsByUserKey = ["items_by_user", item.userId, item.id];
-
-  const res = await kv.atomic()
-    .delete(itemsKey)
-    .delete(itemsByTimeKey)
-    .delete(itemsByUserKey)
-    .commit();
-
-  if (!res.ok) throw new Error(`Failed to delete item: ${item}`);
-}
-
 export async function getItem(id: string) {
   return await getValue<Item>(["items", id]);
 }

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1,6 +1,4 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { DAY, WEEK } from "std/datetime/constants.ts";
-
 export const kv = await Deno.openKv();
 
 // Helpers
@@ -23,75 +21,106 @@ async function getValues<T>(
 }
 
 // Item
-interface InitItem {
+export interface Item {
   userId: string;
   title: string;
   url: string;
-}
-
-export interface Item extends InitItem {
+  // The below properties can be automatically generated upon item creation
   id: string;
   createdAt: Date;
   score: number;
 }
 
-export async function createItem(initItem: InitItem) {
-  const item: Item = {
+export function newItemProps(): Omit<Item, "userId" | "title" | "url"> {
+  return {
     id: crypto.randomUUID(),
     score: 0,
     createdAt: new Date(),
-    ...initItem,
   };
+}
 
-  const itemKey = ["items", item.id];
-  const itemByTime = ["items_by_time", item.createdAt.getTime(), item.id];
+/**
+ * Sets an item in KV.
+ *
+ * @example New item creation
+ * ```ts
+ * import { newItemProps, setItem, incrementAnalyticsMetricPerDay } from "@/utils/db.ts";
+ *
+ * const item: Item = {
+ *   userId: "example-user-id",
+ *   title: "example-title",
+ *   url: "https://example.com"
+ *   ..newItemProps(),
+ * };
+ *
+ * await setItem(item);
+ * await incrementAnalyticsMetricPerDay("items_count", item.createdAt);
+ * ```
+ */
+export async function setItem(item: Item) {
+  const itemsKey = ["items", item.id];
+  const itemsByTimeKey = ["items_by_time", item.createdAt.getTime(), item.id];
   const itemsByUserKey = ["items_by_user", item.userId, item.id];
 
   const res = await kv.atomic()
-    .check({ key: itemKey, versionstamp: null })
-    .check({ key: itemByTime, versionstamp: null })
-    .check({ key: itemsByUserKey, versionstamp: null })
-    .set(itemKey, item)
-    .set(itemByTime, item)
+    .set(itemsKey, item)
+    .set(itemsByTimeKey, item)
     .set(itemsByUserKey, item)
     .commit();
 
   if (!res.ok) throw new Error(`Failed to set item: ${item}`);
-
-  await incrementAnalyticsMetricPerDay("items_count", new Date());
-
-  return item;
 }
 
-export async function getAllItemsInTimeAgo(timeAgo: string) {
-  switch (timeAgo) {
-    case "month":
-      return await getValues<Item>({
-        prefix: ["items_by_time"],
-        start: ["items_by_time", Date.now() - DAY * 30],
-      });
-    case "all":
-      return await getValues<Item>({
-        prefix: ["items_by_time"],
-      });
-    default:
-      return await getValues<Item>({
-        prefix: ["items_by_time"],
-        start: ["items_by_time", Date.now() - WEEK],
-      });
-  }
+export async function deleteItem(item: Item) {
+  const itemsKey = ["items", item.id];
+  const itemsByTimeKey = ["items_by_time", item.createdAt.getTime(), item.id];
+  const itemsByUserKey = ["items_by_user", item.userId, item.id];
+
+  const res = await kv.atomic()
+    .delete(itemsKey)
+    .delete(itemsByTimeKey)
+    .delete(itemsByUserKey)
+    .commit();
+
+  if (!res.ok) throw new Error(`Failed to set item: ${item}`);
 }
 
-export async function getItemById(id: string) {
+export async function getItem(id: string) {
   return await getValue<Item>(["items", id]);
 }
 
-export async function getItemByUser(userId: string, itemId: string) {
-  return await getValue<Item>(["items_by_user", userId, itemId]);
+export async function getItemsByUser(userId: string) {
+  return await getValues<Item>({ prefix: ["items_by_user", userId] });
 }
 
-export async function getItemsByUserId(userId: string) {
-  return await getValues<Item>({ prefix: ["items_by_user", userId] });
+export async function getAllItems() {
+  return await getValues<Item>({ prefix: ["items"] });
+}
+
+/**
+ * Gets all items since a given number of milliseconds ago from KV.
+ *
+ * @example Since a week ago
+ * ```ts
+ * import { WEEK } from "std/datetime/constants.ts";
+ * import { getItemsSince } from "@/utils/db.ts";
+ *
+ * const itemsSinceAllTime = await getItemsSince(WEEK);
+ * ```
+ *
+ * @example Since a month ago
+ * ```ts
+ * import { DAY } from "std/datetime/constants.ts";
+ * import { getItemsSince } from "@/utils/db.ts";
+ *
+ * const itemsSinceAllTime = await getItemsSince(DAY * 30);
+ * ```
+ */
+export async function getItemsSince(msAgo: number) {
+  return await getValues<Item>({
+    prefix: ["items_by_time"],
+    start: ["items_by_time", Date.now() - msAgo],
+  });
 }
 
 // Comment

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -133,7 +133,7 @@ Deno.test("[db] getAllItems()", async () => {
 
   await setItem(item1);
   await setItem(item2);
-  assertEquals(await getAllItems(), [item1, item2]);
+  assertArrayIncludes(await getAllItems(), [item1, item2]);
 
   await deleteItem(item1);
   await deleteItem(item2);
@@ -146,7 +146,6 @@ Deno.test("[db] getItemsSince()", async () => {
     title: crypto.randomUUID(),
     url: `http://${crypto.randomUUID()}.com`,
     ...newItemProps(),
-    createdAt: new Date(Date.now()),
   };
   const item2: Item = {
     userId: crypto.randomUUID(),
@@ -156,11 +155,11 @@ Deno.test("[db] getItemsSince()", async () => {
     createdAt: new Date(Date.now() - (2 * DAY)),
   };
 
-  assertEquals(await getItemsSince(DAY), [item1]);
-  assertEquals(await getItemsSince(3 * DAY), [item1, item2]);
+  await setItem(item1);
+  await setItem(item2);
 
-  await deleteItem(item1);
-  await deleteItem(item2);
+  assertEquals(await getItemsSince(DAY), [item1]);
+  assertArrayIncludes(await getItemsSince(3 * DAY), [item1, item2]);
 });
 
 Deno.test("[db] user", async () => {

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -126,8 +126,7 @@ Deno.test("[db] getItemsByUser()", async () => {
 
   await createItem(item1);
   await createItem(item2);
-  const itemsByUser = await getItemsByUser(userId);
-  assertArrayIncludes(itemsByUser, [item1, item2]);
+  assertArrayIncludes(await getItemsByUser(userId), [item1, item2]);
 });
 
 Deno.test("[db] getItemsSince()", async () => {

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import {
+  createItem,
   createUser,
   deleteItem,
   getAllItems,
@@ -15,7 +16,6 @@ import {
   type Item,
   kv,
   newItemProps,
-  setItem,
   setUserSessionId,
   updateUserIsSubscribed,
   type User,
@@ -24,6 +24,7 @@ import {
   assertAlmostEquals,
   assertArrayIncludes,
   assertEquals,
+  assertRejects,
 } from "std/testing/asserts.ts";
 import { DAY } from "std/datetime/constants.ts";
 
@@ -71,7 +72,7 @@ Deno.test("[db] newItemProps()", () => {
   assertEquals(itemProps.score, 0);
 });
 
-Deno.test("[db] (get/set/delete)Item()", async () => {
+Deno.test("[db] (get/create/delete)Item()", async () => {
   const item: Item = {
     userId: crypto.randomUUID(),
     title: crypto.randomUUID(),
@@ -81,7 +82,8 @@ Deno.test("[db] (get/set/delete)Item()", async () => {
 
   assertEquals(await getItem(item.id), null);
 
-  await setItem(item);
+  await createItem(item);
+  await assertRejects(async () => await createItem(item));
   assertEquals(await getItem(item.id), item);
 
   await deleteItem(item);
@@ -105,8 +107,8 @@ Deno.test("[db] getItemsByUser()", async () => {
 
   assertEquals(await getItemsByUser(userId), []);
 
-  await setItem(item1);
-  await setItem(item2);
+  await createItem(item1);
+  await createItem(item2);
   const itemsByUser = await getItemsByUser(userId);
   assertArrayIncludes(itemsByUser, [item1, item2]);
 
@@ -131,8 +133,8 @@ Deno.test("[db] getAllItems()", async () => {
 
   assertEquals(await getAllItems(), []);
 
-  await setItem(item1);
-  await setItem(item2);
+  await createItem(item1);
+  await createItem(item2);
   assertArrayIncludes(await getAllItems(), [item1, item2]);
 
   await deleteItem(item1);
@@ -155,8 +157,8 @@ Deno.test("[db] getItemsSince()", async () => {
     createdAt: new Date(Date.now() - (2 * DAY)),
   };
 
-  await setItem(item1);
-  await setItem(item2);
+  await createItem(item1);
+  await createItem(item2);
 
   assertEquals(await getItemsSince(DAY), [item1]);
   assertArrayIncludes(await getItemsSince(3 * DAY), [item1, item2]);

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -2,7 +2,6 @@
 import {
   createItem,
   createUser,
-  deleteItem,
   getAllItems,
   getItem,
   getItemsByUser,
@@ -72,7 +71,28 @@ Deno.test("[db] newItemProps()", () => {
   assertEquals(itemProps.score, 0);
 });
 
-Deno.test("[db] (get/create/delete)Item()", async () => {
+Deno.test("[db] getAllItems()", async () => {
+  const item1: Item = {
+    userId: crypto.randomUUID(),
+    title: crypto.randomUUID(),
+    url: `http://${crypto.randomUUID()}.com`,
+    ...newItemProps(),
+  };
+  const item2: Item = {
+    userId: crypto.randomUUID(),
+    title: crypto.randomUUID(),
+    url: `http://${crypto.randomUUID()}.com`,
+    ...newItemProps(),
+  };
+
+  assertEquals(await getAllItems(), []);
+
+  await createItem(item1);
+  await createItem(item2);
+  assertArrayIncludes(await getAllItems(), [item1, item2]);
+});
+
+Deno.test("[db] (get/create)Item()", async () => {
   const item: Item = {
     userId: crypto.randomUUID(),
     title: crypto.randomUUID(),
@@ -85,9 +105,6 @@ Deno.test("[db] (get/create/delete)Item()", async () => {
   await createItem(item);
   await assertRejects(async () => await createItem(item));
   assertEquals(await getItem(item.id), item);
-
-  await deleteItem(item);
-  assertEquals(await getItem(item.id), null);
 });
 
 Deno.test("[db] getItemsByUser()", async () => {
@@ -111,35 +128,6 @@ Deno.test("[db] getItemsByUser()", async () => {
   await createItem(item2);
   const itemsByUser = await getItemsByUser(userId);
   assertArrayIncludes(itemsByUser, [item1, item2]);
-
-  await deleteItem(item1);
-  await deleteItem(item2);
-  assertEquals(await getItemsByUser(userId), []);
-});
-
-Deno.test("[db] getAllItems()", async () => {
-  const item1: Item = {
-    userId: crypto.randomUUID(),
-    title: crypto.randomUUID(),
-    url: `http://${crypto.randomUUID()}.com`,
-    ...newItemProps(),
-  };
-  const item2: Item = {
-    userId: crypto.randomUUID(),
-    title: crypto.randomUUID(),
-    url: `http://${crypto.randomUUID()}.com`,
-    ...newItemProps(),
-  };
-
-  assertEquals(await getAllItems(), []);
-
-  await createItem(item1);
-  await createItem(item2);
-  assertArrayIncludes(await getAllItems(), [item1, item2]);
-
-  await deleteItem(item1);
-  await deleteItem(item2);
-  assertEquals(await getAllItems(), []);
 });
 
 Deno.test("[db] getItemsSince()", async () => {
@@ -160,7 +148,7 @@ Deno.test("[db] getItemsSince()", async () => {
   await createItem(item1);
   await createItem(item2);
 
-  assertEquals(await getItemsSince(DAY), [item1]);
+  assertArrayIncludes(await getItemsSince(DAY), [item1]);
   assertArrayIncludes(await getItemsSince(3 * DAY), [item1, item2]);
 });
 


### PR DESCRIPTION
Before, functions within `util/db.ts` did too much. E.g. `createItem()` generated an item, set it in KV, and then returned the generated item. Now, functions only do one thing, making things easier to understand and maintain.

This is part 1 of a series of PRs that simplifies DB/KV logic. This part focuses on items specifically.

Towards #267