### PR TITLE
chore: set `KV_PATH` environment variable

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
     "db:seed": "deno run --allow-read --allow-env --allow-net --unstable tools/seed_submissions.ts",
     "db:reset": "deno run --allow-read --allow-env --unstable tools/reset_kv.ts",
     "start": "deno run --unstable -A --watch=static/,routes/ dev.ts",
-    "test": "deno test -A --unstable --coverage=./cov",
+    "test": "KV_PATH=:memory: deno test -A --unstable --coverage=./cov",
     "check:license": "deno run --allow-read --allow-write tools/check_license.ts",
     "ok": "deno fmt --check && deno lint && deno task check:license --check && deno check main.ts && deno task test",
     "cov": "deno coverage ./cov/ --lcov --exclude='test.ts' > cov.lcov"

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1,7 +1,15 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { DAY, WEEK } from "std/datetime/constants.ts";
 
-export const kv = await Deno.openKv();
+const KV_PATH_KEY = "KV_PATH";
+let path = undefined;
+if (
+  (await Deno.permissions.query({ name: "env", variable: KV_PATH_KEY }))
+    .state === "granted"
+) {
+  path = Deno.env.get(KV_PATH_KEY);
+}
+export const kv = await Deno.openKv(path);
 
 // Helpers
 async function getValue<T>(


### PR DESCRIPTION
This change allows the `path` in [`Deno.openKv(path)`](https://deno.land/api?s=Deno.openKv&unstable=) to be controlled via the `KV_PATH` environment variable. Tests now use the `:memory:` path, which has a lifetime that ends once tests end, meaning there'll be no clash with production data.

Pre-requisite for #284