### PR TITLE
fix(stats): populate empty chart axis

### DIFF
--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -60,7 +60,13 @@ function LineChart(
             legend: { display: false },
           },
           scales: {
-            y: { grid: { display: false }, beginAtZero: true },
+            y: {
+              beginAtZero: true,
+              grid: { display: false },
+              ticks: {
+                stepSize: 1,
+              },
+            },
             x: { grid: { display: false } },
           },
         }}

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -1,12 +1,12 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { Handlers, PageProps } from "$fresh/server.ts";
+import { DAY } from "std/datetime/constants.ts";
 import { SITE_WIDTH_STYLES } from "@/utils/constants.ts";
 import Head from "@/components/Head.tsx";
 import type { State } from "./_middleware.ts";
 import { getDatesSince, getManyMetrics } from "@/utils/db.ts";
 import { Chart } from "fresh_charts/mod.ts";
 import { ChartColors } from "fresh_charts/utils.ts";
-import { DAY } from "std/datetime/constants.ts";
 
 interface StatsPageData extends State {
   dates: Date[];

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -18,7 +18,7 @@ interface StatsPageData extends State {
 
 export const handler: Handlers<StatsPageData, State> = {
   async GET(_req, ctx) {
-    const msAgo = 10 * DAY;
+    const msAgo = 30 * DAY;
     const dates = getDatesSince(msAgo).map((date) => new Date(date));
 
     const [
@@ -86,6 +86,12 @@ function LineChart(
 }
 
 export default function StatsPage(props: PageProps<StatsPageData>) {
+  const charts: [string, bigint[]][] = [
+    ["Visits", props.data.visitsCounts],
+    ["Users", props.data.usersCounts],
+    ["Items", props.data.itemsCounts],
+    ["Votes", props.data.votesCounts],
+  ];
   const x = props.data.dates.map((date) =>
     new Date(date).toLocaleDateString("en-us", {
       year: "numeric",
@@ -109,26 +115,13 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
       </Head>
       <div class={`${SITE_WIDTH_STYLES} flex-1 px-4`}>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <LineChart
-            title="Visits"
-            x={x}
-            y={props.data.visitsCounts}
-          />
-          <LineChart
-            title="Users"
-            x={x}
-            y={props.data.usersCounts}
-          />
-          <LineChart
-            title="Items"
-            x={x}
-            y={props.data.itemsCounts}
-          />
-          <LineChart
-            title="Votes"
-            x={x}
-            y={props.data.votesCounts}
-          />
+          {charts.map(([title, values]) => (
+            <LineChart
+              title={title}
+              x={x}
+              y={values}
+            />
+          ))}
         </div>
       </div>
     </>

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -63,9 +63,7 @@ function LineChart(
             y: {
               beginAtZero: true,
               grid: { display: false },
-              ticks: {
-                stepSize: 1,
-              },
+              ticks: { stepSize: 1 },
             },
             x: { grid: { display: false } },
           },

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1,4 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import { DAY } from "https://deno.land/std@0.192.0/datetime/constants.ts";
 
 const KV_PATH_KEY = "KV_PATH";
 let path = undefined;
@@ -161,7 +162,8 @@ export function newCommentProps(): Pick<Comment, "id" | "createdAt"> {
 export async function createComment(comment: Comment) {
   const commentsByItemKey = ["comments_by_item", comment.itemId, comment.id];
 
-  const res = await kv.atomic()
+  const res = await kv
+    .atomic()
     .check({ key: commentsByItemKey, versionstamp: null })
     .set(commentsByItemKey, comment)
     .commit();
@@ -216,7 +218,8 @@ export async function createVote(vote: Vote) {
     itemsByTimeKey,
     itemsByUserKey,
   ]);
-  const res = await kv.atomic()
+  const res = await kv
+    .atomic()
     .check(itemRes)
     .check(itemsByTimeRes)
     .check(itemsByUserRes)
@@ -261,7 +264,8 @@ export async function deleteVote(vote: Vote) {
     itemsByTimeKey,
     itemsByUserKey,
   ]);
-  const res = await kv.atomic()
+  const res = await kv
+    .atomic()
     .check(itemRes)
     .check(itemsByTimeRes)
     .check(itemsByUserRes)
@@ -383,9 +387,11 @@ export async function getUserByLogin(login: string) {
 
 export async function getUserBySession(sessionId: string) {
   const usersBySessionKey = ["users_by_session", sessionId];
-  return await getValue<User>(usersBySessionKey, {
-    consistency: "eventual",
-  }) ?? await getValue<User>(usersBySessionKey);
+  return (
+    (await getValue<User>(usersBySessionKey, {
+      consistency: "eventual",
+    })) ?? (await getValue<User>(usersBySessionKey))
+  );
 }
 
 export async function getUserByStripeCustomer(stripeCustomerId: string) {

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1,6 +1,4 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { DAY } from "https://deno.land/std@0.192.0/datetime/constants.ts";
-
 const KV_PATH_KEY = "KV_PATH";
 let path = undefined;
 if (
@@ -28,6 +26,20 @@ async function getValues<T>(
   const iter = kv.list<T>(selector, options);
   for await (const { value } of iter) values.push(value);
   return values;
+}
+
+/** Gets all dates since a given number of milliseconds ago */
+export function getDatesSince(msAgo: number) {
+  const dates = [];
+  const now = Date.now();
+  const start = new Date(now - msAgo);
+
+  while (+start < now) {
+    start.setDate(start.getDate() + 1);
+    dates.push(formatDate(new Date(start)));
+  }
+
+  return dates;
 }
 
 /** Converts `Date` to ISO format that is zero UTC offset */
@@ -428,20 +440,6 @@ export async function incrVisitsCountByDay(date: Date) {
   await kv.atomic()
     .sum(visitsKey, 1n)
     .commit();
-}
-
-/** Gets all dates since a given number of milliseconds ago */
-export function getDatesSince(msAgo: number) {
-  const dates = [];
-  const now = Date.now();
-  const start = new Date(now - msAgo);
-
-  while (+start < now) {
-    start.setDate(start.getDate() + 1);
-    dates.push(formatDate(new Date(start)));
-  }
-
-  return dates;
 }
 
 export async function getManyMetrics(

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -449,7 +449,7 @@ export function compareScore(a: Item, b: Item) {
 
 // Analytics
 export async function incrVisitsCountByDay(date: Date) {
-  const visitsKey = ["visits_count", `${formatDate(date)}`];
+  const visitsKey = ["visits_count", formatDate(date)];
   await kv.atomic()
     .sum(visitsKey, 1n)
     .commit();

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -218,8 +218,7 @@ export async function createVote(vote: Vote) {
     itemsByTimeKey,
     itemsByUserKey,
   ]);
-  const res = await kv
-    .atomic()
+  const res = await kv.atomic()
     .check(itemRes)
     .check(itemsByTimeRes)
     .check(itemsByUserRes)
@@ -264,8 +263,7 @@ export async function deleteVote(vote: Vote) {
     itemsByTimeKey,
     itemsByUserKey,
   ]);
-  const res = await kv
-    .atomic()
+  const res = await kv.atomic()
     .check(itemRes)
     .check(itemsByTimeRes)
     .check(itemsByUserRes)
@@ -387,11 +385,9 @@ export async function getUserByLogin(login: string) {
 
 export async function getUserBySession(sessionId: string) {
   const usersBySessionKey = ["users_by_session", sessionId];
-  return (
-    (await getValue<User>(usersBySessionKey, {
-      consistency: "eventual",
-    })) ?? (await getValue<User>(usersBySessionKey))
-  );
+  return await getValue<User>(usersBySessionKey, {
+    consistency: "eventual",
+  }) ?? await getValue<User>(usersBySessionKey);
 }
 
 export async function getUserByStripeCustomer(stripeCustomerId: string) {

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -36,11 +36,13 @@ async function getValues<T>(
 async function getManyValues<T>(
   keys: Deno.KvKey[],
 ): Promise<(T | null)[]> {
-  const res: (T | null)[] = [];
+  const promises = [];
   for (const batch of chunk(keys, 10)) {
-    res.push(...(await kv.getMany<T[]>(batch)).map((entry) => entry?.value));
+    promises.push(kv.getMany<T[]>(batch));
   }
-  return res;
+  return (await Promise.all(promises))
+    .flat()
+    .map((entry) => entry?.value);
 }
 
 /** Gets all dates since a given number of milliseconds ago */

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -350,7 +350,6 @@ export async function updateUser(user: User) {
   const usersByLoginKey = ["users_by_login", user.login];
   const usersBySessionKey = ["users_by_session", user.sessionId];
 
-<<<<<<< HEAD
   const atomicOp = kv.atomic();
 
   if (user.stripeCustomerId !== undefined) {
@@ -363,9 +362,6 @@ export async function updateUser(user: User) {
   }
 
   const res = await atomicOp
-=======
-  const res = await kv.atomic()
->>>>>>> e6ae61b (chore: revert unintended formatting)
     .set(usersKey, user)
     .set(usersByLoginKey, user)
     .set(usersBySessionKey, user)

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -432,11 +432,7 @@ export function compareScore(a: Item, b: Item) {
 
 // Analytics
 export async function incrVisitsCountByDay(date: Date) {
-  // convert to ISO format that is zero UTC offset
-  const visitsKey = [
-    "visits_count",
-    formatDate(date),
-  ];
+  const visitsKey = ["visits_count", `${formatDate(date)}`];
   await kv.atomic()
     .sum(visitsKey, 1n)
     .commit();

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -162,8 +162,7 @@ export function newCommentProps(): Pick<Comment, "id" | "createdAt"> {
 export async function createComment(comment: Comment) {
   const commentsByItemKey = ["comments_by_item", comment.itemId, comment.id];
 
-  const res = await kv
-    .atomic()
+  const res = await kv.atomic()
     .check({ key: commentsByItemKey, versionstamp: null })
     .set(commentsByItemKey, comment)
     .commit();
@@ -351,6 +350,7 @@ export async function updateUser(user: User) {
   const usersByLoginKey = ["users_by_login", user.login];
   const usersBySessionKey = ["users_by_session", user.sessionId];
 
+<<<<<<< HEAD
   const atomicOp = kv.atomic();
 
   if (user.stripeCustomerId !== undefined) {
@@ -363,6 +363,9 @@ export async function updateUser(user: User) {
   }
 
   const res = await atomicOp
+=======
+  const res = await kv.atomic()
+>>>>>>> e6ae61b (chore: revert unintended formatting)
     .set(usersKey, user)
     .set(usersByLoginKey, user)
     .set(usersBySessionKey, user)

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -215,6 +215,14 @@ Deno.test("[db] votes", async () => {
   assertRejects(async () => await deleteVote({ item, user }));
 });
 
+Deno.test("[db] getManyMetrics()", async () => {
+  const last5Days = getDatesSince(DAY * 5).map((date) => new Date(date));
+  const last30Days = getDatesSince(DAY * 30).map((date) => new Date(date));
+
+  assertEquals((await getManyMetrics("items_count", last5Days)).length, 5);
+  assertEquals((await getManyMetrics("items_count", last30Days)).length, 30);
+});
+
 Deno.test("[db] formatDate()", () => {
   assertEquals(formatDate(new Date("2023-01-01")), "2023-01-01");
   assertEquals(formatDate(new Date("2023-01-01T13:59:08.740Z")), "2023-01-01");

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -11,7 +11,6 @@ import {
   deleteVote,
   formatDate,
   getAllItems,
-  getAnalyticsMetricsSince,
   getCommentsByItem,
   getDatesSince,
   getItem,
@@ -216,7 +215,6 @@ Deno.test("[db] votes", async () => {
   assertRejects(async () => await deleteVote({ item, user }));
 });
 
-<<<<<<< HEAD
 Deno.test("[db] formatDate()", () => {
   assertEquals(formatDate(new Date("2023-01-01")), "2023-01-01");
   assertEquals(formatDate(new Date("2023-01-01T13:59:08.740Z")), "2023-01-01");
@@ -229,118 +227,4 @@ Deno.test("[db] getDatesSince()", () => {
     formatDate(new Date(Date.now() - DAY)),
     formatDate(new Date()),
   ]);
-=======
-Deno.test("[db] getAnalyticsMetricsSince", async () => {
-  const today = new Date();
-  const yesterday = new Date(+today - DAY);
-  const twoDaysAgo = new Date(+today - 2 * DAY);
-
-  const visitsCountToday = Number(
-    (await getVisitsCountByDay(today))?.valueOf() ?? 0n,
-  );
-  const visitsCountYesterday = Number(
-    (await getVisitsCountByDay(yesterday))?.valueOf() ?? 0n,
-  );
-  const visitsCountTwoDaysAgo = Number(
-    (await getVisitsCountByDay(twoDaysAgo))?.valueOf() ?? 0n,
-  );
-
-  assertEquals(await getAnalyticsMetricsSince("", 0), {
-    dates: [],
-    metricsValue: [],
-  });
-  assertEquals(await getAnalyticsMetricsSince("visits_count", DAY), {
-    dates: [formatDate(today)],
-    metricsValue: [visitsCountToday],
-  });
-
-  await incrVisitsCountByDay(today);
-  await incrVisitsCountByDay(today);
-
-  assertEquals(await getAnalyticsMetricsSince("visits_count", DAY), {
-    dates: [formatDate(today)],
-    metricsValue: [visitsCountToday + 2],
-  });
-
-  await incrVisitsCountByDay(yesterday);
-
-  assertEquals(await getAnalyticsMetricsSince("visits_count", DAY * 2), {
-    dates: [formatDate(yesterday), formatDate(today)],
-    metricsValue: [visitsCountYesterday + 1, visitsCountToday + 2],
-  });
-  assertEquals(await getAnalyticsMetricsSince("visits_count", DAY * 3), {
-    dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
-    metricsValue: [
-      visitsCountTwoDaysAgo,
-      visitsCountYesterday + 1,
-      visitsCountToday + 2,
-    ],
-  });
-});
-
-Deno.test("[db] getManyAnalyticsMetricsSince", async () => {
-  const today = new Date();
-  const yesterday = new Date(+today - DAY);
-  const twoDaysAgo = new Date(+today - 2 * DAY);
-
-  const usersCountToday = Number(
-    (await getUsersCountByDay(today))?.valueOf() ?? 0n,
-  );
-  const usersCountYesterday = Number(
-    (await getUsersCountByDay(yesterday))?.valueOf() ?? 0n,
-  );
-  const usersCountTwoDaysAgo = Number(
-    (await getUsersCountByDay(twoDaysAgo))?.valueOf() ?? 0n,
-  );
-
-  const itemsCountToday = Number(
-    (await getItemsCountByDay(today))?.valueOf() ?? 0n,
-  );
-  const itemsCountYesterday = Number(
-    (await getItemsCountByDay(yesterday))?.valueOf() ?? 0n,
-  );
-  const itemsCountTwoDaysAgo = Number(
-    (await getItemsCountByDay(twoDaysAgo))?.valueOf() ?? 0n,
-  );
-
-  assertEquals(await getManyAnalyticsMetricsSince([], 0), []);
-  assertEquals(
-    await getManyAnalyticsMetricsSince(["users_count", "items_count"], 0),
-    [{
-      dates: [],
-      metricsValue: [],
-    }, {
-      dates: [],
-      metricsValue: [],
-    }],
-  );
-  assertEquals(
-    await getManyAnalyticsMetricsSince(["users_count", "items_count"], DAY),
-    [{
-      dates: [formatDate(today)],
-      metricsValue: [usersCountToday],
-    }, {
-      dates: [formatDate(today)],
-      metricsValue: [itemsCountToday],
-    }],
-  );
-  assertEquals(
-    await getManyAnalyticsMetricsSince(["users_count", "items_count"], DAY * 3),
-    [{
-      dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
-      metricsValue: [
-        usersCountTwoDaysAgo,
-        usersCountYesterday,
-        usersCountToday,
-      ],
-    }, {
-      dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
-      metricsValue: [
-        itemsCountTwoDaysAgo,
-        itemsCountYesterday,
-        itemsCountToday,
-      ],
-    }],
-  );
->>>>>>> 6280473 (chore: tweak tests)
 });

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -216,6 +216,7 @@ Deno.test("[db] votes", async () => {
   assertRejects(async () => await deleteVote({ item, user }));
 });
 
+<<<<<<< HEAD
 Deno.test("[db] formatDate()", () => {
   assertEquals(formatDate(new Date("2023-01-01")), "2023-01-01");
   assertEquals(formatDate(new Date("2023-01-01T13:59:08.740Z")), "2023-01-01");
@@ -228,4 +229,76 @@ Deno.test("[db] getDatesSince()", () => {
     formatDate(new Date(Date.now() - DAY)),
     formatDate(new Date()),
   ]);
+=======
+Deno.test("[db] getAnalyticsMetricsSince", async () => {
+  const today = new Date();
+  const yesterday = new Date(+today - DAY);
+  const twoDaysAgo = new Date(+today - 2 * DAY);
+
+  assertEquals(await getAnalyticsMetricsSince("", 0), {
+    dates: [],
+    metricsValue: [],
+  });
+  assertEquals(await getAnalyticsMetricsSince("visits_count", DAY), {
+    dates: [formatDate(today)],
+    metricsValue: [0],
+  });
+
+  await incrAnalyticsMetricPerDay("visits_count", today);
+  await incrAnalyticsMetricPerDay("visits_count", today);
+  await incrAnalyticsMetricPerDay("visits_count", yesterday);
+
+  assertEquals(await getAnalyticsMetricsSince("visits_count", DAY), {
+    dates: [formatDate(today)],
+    metricsValue: [2],
+  });
+  assertEquals(await getAnalyticsMetricsSince("visits_count", DAY * 2), {
+    dates: [formatDate(yesterday), formatDate(today)],
+    metricsValue: [1, 2],
+  });
+  assertEquals(await getAnalyticsMetricsSince("visits_count", DAY * 3), {
+    dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
+    metricsValue: [0, 1, 2],
+  });
+});
+
+Deno.test("[db] getManyAnalyticsMetricsSince", async () => {
+  const today = new Date();
+  const yesterday = new Date(+today - DAY);
+  const twoDaysAgo = new Date(+today - 2 * DAY);
+
+  assertEquals(await getManyAnalyticsMetricsSince([], 0), []);
+  assertEquals(
+    await getManyAnalyticsMetricsSince(["users_count", "items_count"], 0),
+    [{
+      dates: [],
+      metricsValue: [],
+    }, {
+      dates: [],
+      metricsValue: [],
+    }],
+  );
+
+  assertEquals(
+    await getManyAnalyticsMetricsSince(["users_count", "items_count"], DAY),
+    [{
+      dates: [formatDate(today)],
+      metricsValue: [2],
+    }, {
+      dates: [formatDate(today)],
+      metricsValue: [7],
+    }],
+  );
+
+  assertEquals(
+    await getManyAnalyticsMetricsSince(["users_count", "items_count"], DAY * 3),
+    [{
+      dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
+      metricsValue: [0, 0, 2],
+    }, {
+      dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
+      metricsValue: [0, 0, 7],
+    }],
+  );
+>>>>>>> 6280473 (chore: tweak tests)
 });

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -278,7 +278,6 @@ Deno.test("[db] getManyAnalyticsMetricsSince", async () => {
       metricsValue: [],
     }],
   );
-
   assertEquals(
     await getManyAnalyticsMetricsSince(["users_count", "items_count"], DAY),
     [{
@@ -289,7 +288,6 @@ Deno.test("[db] getManyAnalyticsMetricsSince", async () => {
       metricsValue: [7],
     }],
   );
-
   assertEquals(
     await getManyAnalyticsMetricsSince(["users_count", "items_count"], DAY * 3),
     [{

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -235,10 +235,15 @@ Deno.test("[db] getAnalyticsMetricsSince", async () => {
   const yesterday = new Date(+today - DAY);
   const twoDaysAgo = new Date(+today - 2 * DAY);
 
-  const visitsCountToday = Number((await getVisitsCountByDay(today))?.valueOf() ?? 0n);
-  const visitsCountYesterday = Number((await getVisitsCountByDay(yesterday))?.valueOf() ?? 0n)
-  const visitsCountTwoDaysAgo = Number((await getVisitsCountByDay(twoDaysAgo))?.valueOf() ?? 0n)
-
+  const visitsCountToday = Number(
+    (await getVisitsCountByDay(today))?.valueOf() ?? 0n,
+  );
+  const visitsCountYesterday = Number(
+    (await getVisitsCountByDay(yesterday))?.valueOf() ?? 0n,
+  );
+  const visitsCountTwoDaysAgo = Number(
+    (await getVisitsCountByDay(twoDaysAgo))?.valueOf() ?? 0n,
+  );
 
   assertEquals(await getAnalyticsMetricsSince("", 0), {
     dates: [],
@@ -265,7 +270,11 @@ Deno.test("[db] getAnalyticsMetricsSince", async () => {
   });
   assertEquals(await getAnalyticsMetricsSince("visits_count", DAY * 3), {
     dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
-    metricsValue: [visitsCountTwoDaysAgo, visitsCountYesterday + 1, visitsCountToday + 2],
+    metricsValue: [
+      visitsCountTwoDaysAgo,
+      visitsCountYesterday + 1,
+      visitsCountToday + 2,
+    ],
   });
 });
 
@@ -274,13 +283,25 @@ Deno.test("[db] getManyAnalyticsMetricsSince", async () => {
   const yesterday = new Date(+today - DAY);
   const twoDaysAgo = new Date(+today - 2 * DAY);
 
-  const usersCountToday = Number((await getUsersCountByDay(today))?.valueOf() ?? 0n);
-  const usersCountYesterday = Number((await getUsersCountByDay(yesterday))?.valueOf() ?? 0n);
-  const usersCountTwoDaysAgo = Number((await getUsersCountByDay(twoDaysAgo))?.valueOf() ?? 0n);
+  const usersCountToday = Number(
+    (await getUsersCountByDay(today))?.valueOf() ?? 0n,
+  );
+  const usersCountYesterday = Number(
+    (await getUsersCountByDay(yesterday))?.valueOf() ?? 0n,
+  );
+  const usersCountTwoDaysAgo = Number(
+    (await getUsersCountByDay(twoDaysAgo))?.valueOf() ?? 0n,
+  );
 
-  const itemsCountToday = Number((await getItemsCountByDay(today))?.valueOf() ?? 0n);
-  const itemsCountYesterday = Number((await getItemsCountByDay(yesterday))?.valueOf() ?? 0n);
-  const itemsCountTwoDaysAgo = Number((await getItemsCountByDay(twoDaysAgo))?.valueOf() ?? 0n);
+  const itemsCountToday = Number(
+    (await getItemsCountByDay(today))?.valueOf() ?? 0n,
+  );
+  const itemsCountYesterday = Number(
+    (await getItemsCountByDay(yesterday))?.valueOf() ?? 0n,
+  );
+  const itemsCountTwoDaysAgo = Number(
+    (await getItemsCountByDay(twoDaysAgo))?.valueOf() ?? 0n,
+  );
 
   assertEquals(await getManyAnalyticsMetricsSince([], 0), []);
   assertEquals(
@@ -307,10 +328,18 @@ Deno.test("[db] getManyAnalyticsMetricsSince", async () => {
     await getManyAnalyticsMetricsSince(["users_count", "items_count"], DAY * 3),
     [{
       dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
-      metricsValue: [usersCountTwoDaysAgo, usersCountYesterday, usersCountToday],
+      metricsValue: [
+        usersCountTwoDaysAgo,
+        usersCountYesterday,
+        usersCountToday,
+      ],
     }, {
       dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
-      metricsValue: [itemsCountTwoDaysAgo, itemsCountYesterday, itemsCountToday],
+      metricsValue: [
+        itemsCountTwoDaysAgo,
+        itemsCountYesterday,
+        itemsCountToday,
+      ],
     }],
   );
 >>>>>>> 6280473 (chore: tweak tests)

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -235,30 +235,37 @@ Deno.test("[db] getAnalyticsMetricsSince", async () => {
   const yesterday = new Date(+today - DAY);
   const twoDaysAgo = new Date(+today - 2 * DAY);
 
+  const visitsCountToday = Number((await getVisitsCountByDay(today))?.valueOf() ?? 0n);
+  const visitsCountYesterday = Number((await getVisitsCountByDay(yesterday))?.valueOf() ?? 0n)
+  const visitsCountTwoDaysAgo = Number((await getVisitsCountByDay(twoDaysAgo))?.valueOf() ?? 0n)
+
+
   assertEquals(await getAnalyticsMetricsSince("", 0), {
     dates: [],
     metricsValue: [],
   });
   assertEquals(await getAnalyticsMetricsSince("visits_count", DAY), {
     dates: [formatDate(today)],
-    metricsValue: [0],
+    metricsValue: [visitsCountToday],
   });
 
   await incrVisitsCountByDay(today);
   await incrVisitsCountByDay(today);
-  await incrVisitsCountByDay(yesterday);
 
   assertEquals(await getAnalyticsMetricsSince("visits_count", DAY), {
     dates: [formatDate(today)],
-    metricsValue: [2],
+    metricsValue: [visitsCountToday + 2],
   });
+
+  await incrVisitsCountByDay(yesterday);
+
   assertEquals(await getAnalyticsMetricsSince("visits_count", DAY * 2), {
     dates: [formatDate(yesterday), formatDate(today)],
-    metricsValue: [1, 2],
+    metricsValue: [visitsCountYesterday + 1, visitsCountToday + 2],
   });
   assertEquals(await getAnalyticsMetricsSince("visits_count", DAY * 3), {
     dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
-    metricsValue: [0, 1, 2],
+    metricsValue: [visitsCountTwoDaysAgo, visitsCountYesterday + 1, visitsCountToday + 2],
   });
 });
 
@@ -266,6 +273,14 @@ Deno.test("[db] getManyAnalyticsMetricsSince", async () => {
   const today = new Date();
   const yesterday = new Date(+today - DAY);
   const twoDaysAgo = new Date(+today - 2 * DAY);
+
+  const usersCountToday = Number((await getUsersCountByDay(today))?.valueOf() ?? 0n);
+  const usersCountYesterday = Number((await getUsersCountByDay(yesterday))?.valueOf() ?? 0n);
+  const usersCountTwoDaysAgo = Number((await getUsersCountByDay(twoDaysAgo))?.valueOf() ?? 0n);
+
+  const itemsCountToday = Number((await getItemsCountByDay(today))?.valueOf() ?? 0n);
+  const itemsCountYesterday = Number((await getItemsCountByDay(yesterday))?.valueOf() ?? 0n);
+  const itemsCountTwoDaysAgo = Number((await getItemsCountByDay(twoDaysAgo))?.valueOf() ?? 0n);
 
   assertEquals(await getManyAnalyticsMetricsSince([], 0), []);
   assertEquals(
@@ -282,20 +297,20 @@ Deno.test("[db] getManyAnalyticsMetricsSince", async () => {
     await getManyAnalyticsMetricsSince(["users_count", "items_count"], DAY),
     [{
       dates: [formatDate(today)],
-      metricsValue: [2],
+      metricsValue: [usersCountToday],
     }, {
       dates: [formatDate(today)],
-      metricsValue: [7],
+      metricsValue: [itemsCountToday],
     }],
   );
   assertEquals(
     await getManyAnalyticsMetricsSince(["users_count", "items_count"], DAY * 3),
     [{
       dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
-      metricsValue: [0, 0, 2],
+      metricsValue: [usersCountTwoDaysAgo, usersCountYesterday, usersCountToday],
     }, {
       dates: [formatDate(twoDaysAgo), formatDate(yesterday), formatDate(today)],
-      metricsValue: [0, 0, 7],
+      metricsValue: [itemsCountTwoDaysAgo, itemsCountYesterday, itemsCountToday],
     }],
   );
 >>>>>>> 6280473 (chore: tweak tests)

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -11,6 +11,7 @@ import {
   deleteVote,
   formatDate,
   getAllItems,
+  getAnalyticsMetricsSince,
   getCommentsByItem,
   getDatesSince,
   getItem,

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -244,9 +244,9 @@ Deno.test("[db] getAnalyticsMetricsSince", async () => {
     metricsValue: [0],
   });
 
-  await incrAnalyticsMetricPerDay("visits_count", today);
-  await incrAnalyticsMetricPerDay("visits_count", today);
-  await incrAnalyticsMetricPerDay("visits_count", yesterday);
+  await incrVisitsCountByDay(today);
+  await incrVisitsCountByDay(today);
+  await incrVisitsCountByDay(yesterday);
 
   assertEquals(await getAnalyticsMetricsSince("visits_count", DAY), {
     dates: [formatDate(today)],


### PR DESCRIPTION
closes #276.

sets the y-axis' ticks to be of natural numbers.
populates the x-axis with sequential dates.

to prevent us from having "holes" in the retrieved dates, a new `getDatesSince` has been introduced.
the returned array can then can be used to query the necessary fields from our analytics stores.

<img width="1007" alt="Bildschirm­foto 2023-06-22 um 23 42 37" src="https://github.com/denoland/saaskit/assets/8133892/728ebd6f-1a82-42f9-80e8-e0e50248128e">
