### PR TITLE
fix(blog): respect user theme choice

### DIFF
--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -36,6 +36,9 @@ export default function PostPage(props: PageProps<BlogPostPageData>) {
         </time>
         <div
           class="mt-8 markdown-body"
+          data-color-mode="auto"
+          data-light-theme="light"
+          data-dark-theme="dark"
           dangerouslySetInnerHTML={{ __html: render(post.content) }}
         />
       </main>

--- a/routes/blog/index.tsx
+++ b/routes/blog/index.tsx
@@ -21,7 +21,7 @@ function PostCard(props: Post) {
   return (
     <div class="py-8 border(t gray-200)">
       <a class="sm:col-span-2" href={`/blog/${props.slug}`}>
-        <h3 class="text(3xl gray-900) font-bold">
+        <h3 class="text-3xl font-bold">
           {props.title}
         </h3>
         {props.publishedAt.toString() !== "Invalid Date" && (
@@ -31,7 +31,7 @@ function PostCard(props: Post) {
             })}
           </time>
         )}
-        <div class="mt-4 text-gray-900">
+        <div class="mt-4">
           {props.summary}
         </div>
       </a>


### PR DESCRIPTION
At the moment the blog is not readable since it has css classes set only for a light theme. Since SaaSKit changed to support both light and dark themes the blog also needs to support that. This fixes the CSS on the SaaSKit side. However since we use `deno-gfm` we might think about adding our own CSS to for the rendered markdown files.