### PR TITLE
test(utils): further improve test coverage

### DIFF
--- a/data/posts/second-post.md
+++ b/data/posts/second-post.md
@@ -1,7 +1,5 @@
 ---
 title: Second post
-published_at: 2022-03-20
-summary: This is the second post.
 ---
 
 It was popularised in the 1960s with the release of Letraset sheets containing

--- a/routes/blog/[slug].tsx
+++ b/routes/blog/[slug].tsx
@@ -20,9 +20,10 @@ export const handler: Handlers<BlogPostPageData, State> = {
 
 export default function PostPage(props: PageProps<BlogPostPageData>) {
   const { post } = props.data;
-  const date = new Date(post.publishedAt).toLocaleDateString("en-US", {
-    dateStyle: "long",
-  });
+  const date = post.publishedAt.toString() !== "Invalid Date" &&
+    new Date(post.publishedAt).toLocaleDateString("en-US", {
+      dateStyle: "long",
+    });
 
   return (
     <>
@@ -31,9 +32,11 @@ export default function PostPage(props: PageProps<BlogPostPageData>) {
       </Head>
       <main class={`${SITE_WIDTH_STYLES} px-4 pt-16 flex-1`}>
         <h1 class="text-5xl font-bold">{post.title}</h1>
-        <time class="text-gray-500">
-          {date}
-        </time>
+        {date && (
+          <time class="text-gray-500">
+            {date}
+          </time>
+        )}
         <div
           class="mt-8 markdown-body"
           data-color-mode="auto"

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -4,7 +4,9 @@ import {
   createComment,
   createItem,
   createUser,
+  createVote,
   deleteUserBySession,
+  deleteVote,
   getAllItems,
   getCommentsByItem,
   getItem,
@@ -16,6 +18,7 @@ import {
   getUserBySession,
   getUserByStripeCustomer,
   getVisitsPerDay,
+  getVotedItemsByUser,
   incrementVisitsPerDay,
   type Item,
   kv,
@@ -33,92 +36,25 @@ import {
 } from "std/testing/asserts.ts";
 import { DAY } from "std/datetime/constants.ts";
 
-Deno.test("[db] newItemProps()", () => {
-  const itemProps = newItemProps();
-  assertAlmostEquals(itemProps.createdAt.getTime(), Date.now());
-  assertEquals(typeof itemProps.id, "string");
-  assertEquals(itemProps.score, 0);
-});
+function genNewComment(comment: Partial<Comment> = {}): Comment {
+  return {
+    itemId: crypto.randomUUID(),
+    userId: crypto.randomUUID(),
+    text: crypto.randomUUID(),
+    ...newCommentProps(),
+    ...comment,
+  };
+}
 
-Deno.test("[db] getAllItems()", async () => {
-  const item1: Item = {
+function genNewItem(item: Partial<Item> = {}): Item {
+  return {
     userId: crypto.randomUUID(),
     title: crypto.randomUUID(),
     url: `http://${crypto.randomUUID()}.com`,
     ...newItemProps(),
+    ...item,
   };
-  const item2: Item = {
-    userId: crypto.randomUUID(),
-    title: crypto.randomUUID(),
-    url: `http://${crypto.randomUUID()}.com`,
-    ...newItemProps(),
-  };
-
-  assertEquals(await getAllItems(), []);
-
-  await createItem(item1);
-  await createItem(item2);
-  assertArrayIncludes(await getAllItems(), [item1, item2]);
-});
-
-Deno.test("[db] (get/create)Item()", async () => {
-  const item: Item = {
-    userId: crypto.randomUUID(),
-    title: crypto.randomUUID(),
-    url: `http://${crypto.randomUUID()}.com`,
-    ...newItemProps(),
-  };
-
-  assertEquals(await getItem(item.id), null);
-
-  await createItem(item);
-  await assertRejects(async () => await createItem(item));
-  assertEquals(await getItem(item.id), item);
-});
-
-Deno.test("[db] getItemsByUser()", async () => {
-  const userId = crypto.randomUUID();
-  const item1: Item = {
-    userId,
-    title: crypto.randomUUID(),
-    url: `http://${crypto.randomUUID()}.com`,
-    ...newItemProps(),
-  };
-  const item2: Item = {
-    userId,
-    title: crypto.randomUUID(),
-    url: `http://${crypto.randomUUID()}.com`,
-    ...newItemProps(),
-  };
-
-  assertEquals(await getItemsByUser(userId), []);
-
-  await createItem(item1);
-  await createItem(item2);
-  assertArrayIncludes(await getItemsByUser(userId), [item1, item2]);
-});
-
-Deno.test("[db] getItemsSince()", async () => {
-  const item1: Item = {
-    userId: crypto.randomUUID(),
-    title: crypto.randomUUID(),
-    url: `http://${crypto.randomUUID()}.com`,
-    ...newItemProps(),
-  };
-  const item2: Item = {
-    userId: crypto.randomUUID(),
-    title: crypto.randomUUID(),
-    url: `http://${crypto.randomUUID()}.com`,
-    ...newItemProps(),
-    createdAt: new Date(Date.now() - (2 * DAY)),
-  };
-
-  await createItem(item1);
-  await createItem(item2);
-
-  assertArrayIncludes(await getItemsSince(DAY), [item1]);
-  assertArrayIncludes(await getItemsSince(3 * DAY), [item1, item2]);
-});
+}
 
 function genNewUser(): User {
   return {
@@ -130,6 +66,59 @@ function genNewUser(): User {
     ...newUserProps(),
   };
 }
+
+Deno.test("[db] newItemProps()", () => {
+  const itemProps = newItemProps();
+  assertAlmostEquals(itemProps.createdAt.getTime(), Date.now());
+  assertEquals(typeof itemProps.id, "string");
+  assertEquals(itemProps.score, 0);
+});
+
+Deno.test("[db] getAllItems()", async () => {
+  const item1 = genNewItem();
+  const item2 = genNewItem();
+
+  assertEquals(await getAllItems(), []);
+
+  await createItem(item1);
+  await createItem(item2);
+  assertArrayIncludes(await getAllItems(), [item1, item2]);
+});
+
+Deno.test("[db] (get/create)Item()", async () => {
+  const item = genNewItem();
+
+  assertEquals(await getItem(item.id), null);
+
+  await createItem(item);
+  await assertRejects(async () => await createItem(item));
+  assertEquals(await getItem(item.id), item);
+});
+
+Deno.test("[db] getItemsByUser()", async () => {
+  const userId = crypto.randomUUID();
+  const item1 = genNewItem({ userId });
+  const item2 = genNewItem({ userId });
+
+  assertEquals(await getItemsByUser(userId), []);
+
+  await createItem(item1);
+  await createItem(item2);
+  assertArrayIncludes(await getItemsByUser(userId), [item1, item2]);
+});
+
+Deno.test("[db] getItemsSince()", async () => {
+  const item1 = genNewItem();
+  const item2 = genNewItem({
+    createdAt: new Date(Date.now() - (2 * DAY)),
+  });
+
+  await createItem(item1);
+  await createItem(item2);
+
+  assertArrayIncludes(await getItemsSince(DAY), [item1]);
+  assertArrayIncludes(await getItemsSince(3 * DAY), [item1, item2]);
+});
 
 Deno.test("[db] user", async () => {
   const user = genNewUser();
@@ -185,18 +174,12 @@ Deno.test("[db] newCommentProps()", () => {
 
 Deno.test("[db] createComment() + getCommentsByItem()", async () => {
   const itemId = crypto.randomUUID();
-  const comment1: Comment = {
+  const comment1 = genNewComment({
     itemId,
-    userId: crypto.randomUUID(),
-    text: crypto.randomUUID(),
-    ...newCommentProps(),
-  };
-  const comment2: Comment = {
+  });
+  const comment2 = genNewComment({
     itemId,
-    userId: crypto.randomUUID(),
-    text: crypto.randomUUID(),
-    ...newCommentProps(),
-  };
+  });
 
   assertEquals(await getCommentsByItem(itemId), []);
 
@@ -204,4 +187,20 @@ Deno.test("[db] createComment() + getCommentsByItem()", async () => {
   await createComment(comment2);
   await assertRejects(async () => await createComment(comment2));
   assertArrayIncludes(await getCommentsByItem(itemId), [comment1, comment2]);
+});
+
+Deno.test("[db] votes", async () => {
+  const user = genNewUser();
+  const item = genNewItem();
+
+  assertEquals(await getVotedItemsByUser(user.id), []);
+
+  await createVote({ item, user });
+  assertEquals(await getVotedItemsByUser(user.id), [item]);
+  await deleteVote({ item, user });
+  assertEquals(await getVotedItemsByUser(user.id), []);
+  await createVote({ item, user });
+  assertRejects(async () => await createVote({ item, user }));
+  await deleteVote({ item, user });
+  assertRejects(async () => await deleteVote({ item, user }));
 });

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -36,7 +36,7 @@ import {
 } from "std/testing/asserts.ts";
 import { DAY } from "std/datetime/constants.ts";
 
-function genNewComment(comment: Partial<Comment> = {}): Comment {
+function genNewComment(comment?: Partial<Comment>): Comment {
   return {
     itemId: crypto.randomUUID(),
     userId: crypto.randomUUID(),
@@ -46,7 +46,7 @@ function genNewComment(comment: Partial<Comment> = {}): Comment {
   };
 }
 
-function genNewItem(item: Partial<Item> = {}): Item {
+function genNewItem(item?: Partial<Item>): Item {
   return {
     userId: crypto.randomUUID(),
     title: crypto.randomUUID(),

--- a/utils/posts.ts
+++ b/utils/posts.ts
@@ -31,7 +31,7 @@ export async function getPost(slug: string): Promise<Post | null> {
     return {
       slug,
       title: attrs.title as string,
-      publishedAt: new Date(attrs.published_at as Date) || null,
+      publishedAt: new Date(attrs.published_at as Date),
       content: body,
       summary: attrs.summary as string || "",
     };

--- a/utils/posts_test.ts
+++ b/utils/posts_test.ts
@@ -11,6 +11,14 @@ Deno.test("[blog] getPost()", async () => {
   assertEquals(post.title, "This is my first blog post!");
 });
 
+Deno.test("[blog] getPost() for missing frontmatter", async () => {
+  const post = await getPost("second-post");
+  assert(post);
+  assertEquals(post.publishedAt, new Date(undefined as unknown as Date));
+  assertEquals(post.summary, "");
+  assertEquals(post.title, "Second post");
+});
+
 Deno.test("[blog] getPost() for non-existent post", async () => {
   const post = await getPost("third-post");
   assertEquals(post, null);

--- a/utils/posts_test.ts
+++ b/utils/posts_test.ts
@@ -11,7 +11,7 @@ Deno.test("[blog] getPost()", async () => {
   assertEquals(post.title, "This is my first blog post!");
 });
 
-Deno.test("[blog] getPost() for missing frontmatter", async () => {
+Deno.test("[blog] getPost() with missing frontmatter attributes", async () => {
   const post = await getPost("second-post");
   assert(post);
   assertEquals(post.publishedAt, new Date(undefined as unknown as Date));


### PR DESCRIPTION
this pr attempts to improve the coverage as mentioned in #267.  

to reduce the boilerplate on writing further tests, a couple `genNew<Entity>` functions have been created.  
these helper functions are now used for all tests cases, if applicable.  