### PR TITLE
feat: redirect to new host

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -2,7 +2,7 @@
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
 import { walk } from "std/fs/walk.ts";
 import { getSessionId } from "kv_oauth";
-import { setRedirectUrlCookie } from "@/utils/redirect.ts";
+import { redirect, setRedirectUrlCookie } from "@/utils/redirect.ts";
 
 export interface State {
   sessionId?: string;
@@ -18,7 +18,12 @@ export async function handler(
   req: Request,
   ctx: MiddlewareHandlerContext<State>,
 ) {
-  const { pathname } = new URL(req.url);
+  const { pathname, hostname } = new URL(req.url);
+
+  if (hostname === "saaskit.deno.dev") {
+    return redirect("https://hunt.deno.land", 302);
+  }
+
   // Don't process session-related data for keepalive and static requests
   if (["_frsh", ...staticFileNames].some((part) => pathname.includes(part))) {
     return await ctx.next();

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -3,6 +3,7 @@ import { MiddlewareHandlerContext } from "$fresh/server.ts";
 import { walk } from "std/fs/walk.ts";
 import { getSessionId } from "kv_oauth";
 import { redirect, setRedirectUrlCookie } from "@/utils/redirect.ts";
+import { Status } from "std/http/http_status.ts";
 
 export interface State {
   sessionId?: string;
@@ -21,7 +22,7 @@ export async function handler(
   const { pathname, hostname } = new URL(req.url);
 
   if (hostname === "saaskit.deno.dev") {
-    return redirect("https://hunt.deno.land", 302);
+    return redirect("https://hunt.deno.land", Status.Found);
   }
 
   // Don't process session-related data for keepalive and static requests


### PR DESCRIPTION
The new home for Deno Hunt is now https://hunt.deno.land