### PR TITLE
refactor: simplify analytics-KV data

### DIFF
--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -18,7 +18,7 @@ interface StatsPageData extends State {
 
 export const handler: Handlers<StatsPageData, State> = {
   async GET(_req, ctx) {
-    const msAgo = 7 * DAY;
+    const msAgo = 10 * DAY;
     const dates = getDatesSince(msAgo);
 
     const [

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -3,41 +3,54 @@ import type { Handlers, PageProps } from "$fresh/server.ts";
 import { SITE_WIDTH_STYLES } from "@/utils/constants.ts";
 import Head from "@/components/Head.tsx";
 import type { State } from "./_middleware.ts";
-import { getManyAnalyticsMetricsPerDay } from "@/utils/db.ts";
+import {
+  getDatesSince,
+  getManyItemsCounts,
+  getManyUsersCounts,
+  getManyVisitsCounts,
+  getManyVotesCounts,
+} from "@/utils/db.ts";
 import { Chart } from "fresh_charts/mod.ts";
 import { ChartColors } from "fresh_charts/utils.ts";
-
-interface AnalyticsByDay {
-  metricsValue: number[];
-  dates: string[];
-}
+import { DAY } from "std/datetime/constants.ts";
 
 interface StatsPageData extends State {
-  metricsByDay: AnalyticsByDay[];
-  metricsTitles: string[];
+  dates: Date[];
+  visitsCounts: bigint[];
+  usersCounts: bigint[];
+  itemsCounts: bigint[];
+  votesCounts: bigint[];
 }
 
 export const handler: Handlers<StatsPageData, State> = {
-  async GET(_, ctx) {
-    const daysBefore = 30;
+  async GET(_req, ctx) {
+    const dates = getDatesSince(DAY * 10);
 
-    const metricsKeys = [
-      "visits_count",
-      "users_count",
-      "items_count",
-      "votes_count",
-    ];
-    const metricsTitles = ["Visits", "New Users", "New Items", "New Votes"];
-    const metricsByDay = await getManyAnalyticsMetricsPerDay(metricsKeys, {
-      limit: daysBefore,
+    const [
+      visitsCounts,
+      usersCounts,
+      itemsCounts,
+      votesCounts,
+    ] = await Promise.all([
+      getManyVisitsCounts(dates),
+      getManyUsersCounts(dates),
+      getManyItemsCounts(dates),
+      getManyVotesCounts(dates),
+    ]);
+
+    return ctx.render({
+      ...ctx.state,
+      dates,
+      visitsCounts,
+      usersCounts,
+      itemsCounts,
+      votesCounts,
     });
-
-    return ctx.render({ ...ctx.state, metricsByDay, metricsTitles });
   },
 };
 
 function LineChart(
-  props: { title: string; x: string[]; y: number[] },
+  props: { title: string; x: string[]; y: bigint[] },
 ) {
   return (
     <div class="py-4 resize lg:chart">
@@ -60,7 +73,7 @@ function LineChart(
           labels: props.x,
           datasets: [{
             label: props.title,
-            data: props.y,
+            data: props.y.map((value) => Number(value)),
             borderColor: ChartColors.Blue,
             backgroundColor: ChartColors.Blue,
             borderWidth: 3,
@@ -74,6 +87,14 @@ function LineChart(
 }
 
 export default function StatsPage(props: PageProps<StatsPageData>) {
+  const x = props.data.dates.map((date) =>
+    new Date(date).toLocaleDateString("en-us", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    })
+  );
+
   return (
     <>
       <Head title="Stats" href={props.url.href}>
@@ -89,19 +110,26 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
       </Head>
       <div class={`${SITE_WIDTH_STYLES} flex-1 px-4`}>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          {props.data.metricsByDay.map((metric, index) => (
-            <LineChart
-              title={props.data.metricsTitles[index]}
-              x={metric.dates!.map((date) =>
-                new Date(date).toLocaleDateString("en-us", {
-                  year: "numeric",
-                  month: "short",
-                  day: "numeric",
-                })
-              )}
-              y={metric.metricsValue!}
-            />
-          ))}
+          <LineChart
+            title="Visits"
+            x={x}
+            y={props.data.visitsCounts}
+          />
+          <LineChart
+            title="Users"
+            x={x}
+            y={props.data.usersCounts}
+          />
+          <LineChart
+            title="Items"
+            x={x}
+            y={props.data.itemsCounts}
+          />
+          <LineChart
+            title="Votes"
+            x={x}
+            y={props.data.votesCounts}
+          />
         </div>
       </div>
     </>

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -3,13 +3,7 @@ import type { Handlers, PageProps } from "$fresh/server.ts";
 import { SITE_WIDTH_STYLES } from "@/utils/constants.ts";
 import Head from "@/components/Head.tsx";
 import type { State } from "./_middleware.ts";
-import {
-  getDatesSince,
-  getManyItemsCounts,
-  getManyUsersCounts,
-  getManyVisitsCounts,
-  getManyVotesCounts,
-} from "@/utils/db.ts";
+import { getDatesSince, getManyMetrics } from "@/utils/db.ts";
 import { Chart } from "fresh_charts/mod.ts";
 import { ChartColors } from "fresh_charts/utils.ts";
 import { DAY } from "std/datetime/constants.ts";
@@ -24,7 +18,8 @@ interface StatsPageData extends State {
 
 export const handler: Handlers<StatsPageData, State> = {
   async GET(_req, ctx) {
-    const dates = getDatesSince(DAY * 10);
+    const msAgo = 7 * DAY;
+    const dates = getDatesSince(msAgo);
 
     const [
       visitsCounts,
@@ -32,10 +27,10 @@ export const handler: Handlers<StatsPageData, State> = {
       itemsCounts,
       votesCounts,
     ] = await Promise.all([
-      getManyVisitsCounts(dates),
-      getManyUsersCounts(dates),
-      getManyItemsCounts(dates),
-      getManyVotesCounts(dates),
+      getManyMetrics("visits_count", dates),
+      getManyMetrics("users_count", dates),
+      getManyMetrics("items_count", dates),
+      getManyMetrics("votes_count", dates),
     ]);
 
     return ctx.render({

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -19,7 +19,7 @@ interface StatsPageData extends State {
 export const handler: Handlers<StatsPageData, State> = {
   async GET(_req, ctx) {
     const msAgo = 10 * DAY;
-    const dates = getDatesSince(msAgo);
+    const dates = getDatesSince(msAgo).map((date) => new Date(date));
 
     const [
       visitsCounts,

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -437,7 +437,7 @@ export function getDatesSince(msAgo: number) {
 
   while (+start < now) {
     start.setDate(start.getDate() + 1);
-    dates.push(new Date(start));
+    dates.push(formatDate(new Date(start)));
   }
 
   return dates;

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -422,7 +422,7 @@ export async function incrVisitsCountByDay(date: Date) {
   // convert to ISO format that is zero UTC offset
   const visitsKey = [
     "visits_count",
-    `${date.toISOString().split("T")[0]}`,
+    formatDate(date),
   ];
   await kv.atomic()
     .sum(visitsKey, 1n)
@@ -443,26 +443,11 @@ export function getDatesSince(msAgo: number) {
   return dates;
 }
 
-export async function getManyVisitsCounts(dates: Date[]) {
-  const keys = dates.map((date) => ["visits_count", formatDate(date)]);
-  const res = await kv.getMany<bigint[]>(keys);
-  return res.map(({ value }) => value?.valueOf() ?? 0n);
-}
-
-export async function getManyItemsCounts(dates: Date[]) {
-  const keys = dates.map((date) => ["items_count", formatDate(date)]);
-  const res = await kv.getMany<bigint[]>(keys);
-  return res.map(({ value }) => value?.valueOf() ?? 0n);
-}
-
-export async function getManyVotesCounts(dates: Date[]) {
-  const keys = dates.map((date) => ["votes_count", formatDate(date)]);
-  const res = await kv.getMany<bigint[]>(keys);
-  return res.map(({ value }) => value?.valueOf() ?? 0n);
-}
-
-export async function getManyUsersCounts(dates: Date[]) {
-  const keys = dates.map((date) => ["users_count", formatDate(date)]);
+export async function getManyMetrics(
+  metric: "visits_count" | "items_count" | "votes_count" | "users_count",
+  dates: Date[],
+) {
+  const keys = dates.map((date) => [metric, formatDate(date)]);
   const res = await kv.getMany<bigint[]>(keys);
   return res.map(({ value }) => value?.valueOf() ?? 0n);
 }

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -429,99 +429,40 @@ export async function incrVisitsCountByDay(date: Date) {
     .commit();
 }
 
-export async function getVisitsCountByDay(date: Date) {
-  return await getValue<bigint>([
-    "visits_count",
-    formatDate(date),
-  ]);
-}
-
-export async function getItemsCountByDay(date: Date) {
-  return await getValue<bigint>([
-    "items_count",
-    formatDate(date),
-  ]);
-}
-
-export async function getVotesCountByDay(date: Date) {
-  return await getValue<bigint>([
-    "votes_count",
-    formatDate(date),
-  ]);
-}
-
-export async function getUsersCountByDay(date: Date) {
-  return await getValue<bigint>([
-    "users_count",
-    formatDate(date),
-  ]);
-}
-
-export async function getAllVisitsCountByDay(options?: Deno.KvListOptions) {
-  const iter = await kv.list<bigint>({ prefix: ["visits_count"] }, options);
-  const visits = [];
+/** Gets all dates since a given number of milliseconds ago */
+export function getDatesSince(msAgo: number) {
   const dates = [];
-  for await (const res of iter) {
-    visits.push(Number(res.value));
-    dates.push(String(res.key[1]));
+  const now = Date.now();
+  const start = new Date(now - msAgo);
+
+  while (+start < now) {
+    start.setDate(start.getDate() + 1);
+    dates.push(new Date(start));
   }
-  return { visits, dates };
+
+  return dates;
 }
 
-export async function getAllItemsCountByDay(options?: Deno.KvListOptions) {
-  const iter = await kv.list<bigint>({ prefix: ["items_count"] }, options);
-  const visits = [];
-  const dates = [];
-  for await (const res of iter) {
-    visits.push(Number(res.value));
-    dates.push(String(res.key[1]));
-  }
-  return { visits, dates };
+export async function getManyVisitsCounts(dates: Date[]) {
+  const keys = dates.map((date) => ["visits_count", formatDate(date)]);
+  const res = await kv.getMany<bigint[]>(keys);
+  return res.map(({ value }) => value?.valueOf() ?? 0n);
 }
 
-export async function getAllVotesCountByDay(options?: Deno.KvListOptions) {
-  const iter = await kv.list<bigint>({ prefix: ["votes_count"] }, options);
-  const visits = [];
-  const dates = [];
-  for await (const res of iter) {
-    visits.push(Number(res.value));
-    dates.push(String(res.key[1]));
-  }
-  return { visits, dates };
+export async function getManyItemsCounts(dates: Date[]) {
+  const keys = dates.map((date) => ["items_count", formatDate(date)]);
+  const res = await kv.getMany<bigint[]>(keys);
+  return res.map(({ value }) => value?.valueOf() ?? 0n);
 }
 
-export async function getAllUsersCountByDay(options?: Deno.KvListOptions) {
-  const iter = await kv.list<bigint>({ prefix: ["users_count"] }, options);
-  const visits = [];
-  const dates = [];
-  for await (const res of iter) {
-    visits.push(Number(res.value));
-    dates.push(String(res.key[1]));
-  }
-  return { visits, dates };
+export async function getManyVotesCounts(dates: Date[]) {
+  const keys = dates.map((date) => ["votes_count", formatDate(date)]);
+  const res = await kv.getMany<bigint[]>(keys);
+  return res.map(({ value }) => value?.valueOf() ?? 0n);
 }
 
-export async function getAnalyticsMetricListPerDay(
-  metric: string,
-  options?: Deno.KvListOptions,
-) {
-  const iter = await kv.list<bigint>({ prefix: [metric] }, options);
-  const metricsValue = [];
-  const dates = [];
-  for await (const res of iter) {
-    metricsValue.push(Number(res.value));
-    dates.push(String(res.key[1]));
-  }
-  return { metricsValue, dates };
-}
-
-export async function getManyAnalyticsMetricsPerDay(
-  metrics: string[],
-  options?: Deno.KvListOptions,
-) {
-  const analyticsByDay = await Promise.all(
-    metrics.map((metric) => getAnalyticsMetricListPerDay(metric, options)),
-  );
-
-  return analyticsByDay;
+export async function getManyUsersCounts(dates: Date[]) {
+  const keys = dates.map((date) => ["users_count", formatDate(date)]);
+  const res = await kv.getMany<bigint[]>(keys);
+  return res.map(({ value }) => value?.valueOf() ?? 0n);
 }

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -14,17 +14,17 @@ import {
   getCommentsByItem,
   getItem,
   getItemsByUser,
-  getItemsCountByDay,
   getItemsSince,
+  getManyItemsCounts,
   getManyUsers,
+  getManyUsersCounts,
+  getManyVisitsCounts,
+  getManyVotesCounts,
   getUser,
   getUserByLogin,
   getUserBySession,
   getUserByStripeCustomer,
-  getUsersCountByDay,
-  getVisitsCountByDay,
   getVotedItemsByUser,
-  getVotesCountByDay,
   incrVisitsCountByDay,
   type Item,
   kv,
@@ -96,13 +96,9 @@ Deno.test("[db] (get/create/delete)Item()", async () => {
 
   assertEquals(await getItem(item.id), null);
 
-  const itemsCount = (await getItemsCountByDay(new Date()))?.valueOf() ??
-    0n;
+  const [itemsCount] = await getManyItemsCounts([new Date()]);
   await createItem(item);
-  assertEquals(
-    (await getItemsCountByDay(new Date()))!.valueOf(),
-    itemsCount + 1n,
-  );
+  assertEquals(await getManyItemsCounts([new Date()]), [itemsCount + 1n]);
   await assertRejects(async () => await createItem(item));
   assertEquals(await getItem(item.id), item);
 
@@ -143,14 +139,10 @@ Deno.test("[db] user", async () => {
   assertEquals(await getUserBySession(user.sessionId), null);
   assertEquals(await getUserByStripeCustomer(user.stripeCustomerId!), null);
 
-  const usersCount = (await getUsersCountByDay(new Date()))
-    ?.valueOf() ?? 0n;
+  const [usersCount] = await getManyUsersCounts([new Date()]);
   await createUser(user);
   await assertRejects(async () => await createUser(user));
-  assertEquals(
-    (await getUsersCountByDay(new Date()))!.valueOf(),
-    usersCount + 1n,
-  );
+  assertEquals(await getManyUsersCounts([new Date()]), [usersCount + 1n]);
   assertEquals(await getUser(user.id), user);
   assertEquals(await getUserByLogin(user.login), user);
   assertEquals(await getUserBySession(user.sessionId), user);
@@ -182,9 +174,9 @@ Deno.test("[db] visit", async () => {
   ];
   await incrVisitsCountByDay(date);
   assertEquals((await kv.get(visitsKey)).key[1], "2023-01-01");
-  assertEquals((await getVisitsCountByDay(date))!.valueOf(), 1n);
+  assertEquals(await getManyVisitsCounts([date]), [1n]);
   await kv.delete(visitsKey);
-  assertEquals(await getVisitsCountByDay(date), null);
+  assertEquals(await getManyVisitsCounts([date]), [0n]);
 });
 
 Deno.test("[db] newCommentProps()", () => {
@@ -220,13 +212,9 @@ Deno.test("[db] votes", async () => {
 
   assertEquals(await getVotedItemsByUser(user.id), []);
 
-  const votesCount = (await getVotesCountByDay(new Date()))?.valueOf() ??
-    0n;
+  const [votesCount] = await getManyVotesCounts([new Date()]);
   await createVote({ item, user });
-  assertEquals(
-    (await getVotesCountByDay(new Date()))!.valueOf(),
-    votesCount + 1n,
-  );
+  assertEquals(await getManyVotesCounts([new Date()]), [votesCount + 1n]);
   assertEquals(await getVotedItemsByUser(user.id), [item]);
   await deleteVote({ item, user });
   assertEquals(await getVotedItemsByUser(user.id), []);

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -12,6 +12,7 @@ import {
   formatDate,
   getAllItems,
   getCommentsByItem,
+  getDatesSince,
   getItem,
   getItemsByUser,
   getItemsSince,
@@ -217,4 +218,13 @@ Deno.test("[db] votes", async () => {
 Deno.test("[db] formatDate()", () => {
   assertEquals(formatDate(new Date("2023-01-01")), "2023-01-01");
   assertEquals(formatDate(new Date("2023-01-01T13:59:08.740Z")), "2023-01-01");
+});
+
+Deno.test("[db] getDatesSince()", () => {
+  assertEquals(getDatesSince(0), []);
+  assertEquals(getDatesSince(DAY), [new Date()]);
+  assertEquals(getDatesSince(DAY * 2), [
+    new Date(Date.now() - DAY),
+    new Date(),
+  ]);
 });

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -222,9 +222,9 @@ Deno.test("[db] formatDate()", () => {
 
 Deno.test("[db] getDatesSince()", () => {
   assertEquals(getDatesSince(0), []);
-  assertEquals(getDatesSince(DAY), [new Date()]);
+  assertEquals(getDatesSince(DAY), [formatDate(new Date())]);
   assertEquals(getDatesSince(DAY * 2), [
-    new Date(Date.now() - DAY),
-    new Date(),
+    formatDate(new Date(Date.now() - DAY)),
+    formatDate(new Date()),
   ]);
 });


### PR DESCRIPTION
Previously, the analytics-related functions in `@/utils/db.ts` did too much. This PR simplifies these functions. I also chose not to hardcode the specific metric value and instead it be a function argument.

PTAL, @brunocorrea23 and @mbhrznr.
Pre-requisite for #289