### PR TITLE
fix: remove deprecated `incrementAnalyticsMetricPerDay()`

### DIFF
--- a/tools/seed_submissions.ts
+++ b/tools/seed_submissions.ts
@@ -3,7 +3,6 @@
 import {
   createItem,
   createUser,
-  incrementAnalyticsMetricPerDay,
   type Item,
   newItemProps,
   newUserProps,
@@ -78,7 +77,6 @@ async function seedSubmissions(stories: Story[]) {
       batch.map((item) =>
         Promise.all([
           createItem(item),
-          incrementAnalyticsMetricPerDay("items_count", new Date()),
         ])
       ),
     );


### PR DESCRIPTION
`incrementAnalyticsMetricPerDay` does not exist anymore in `db.ts`.
This pull request just remove invalid imports.
When I ran the `db:seed` task during `saaskit` startup, I got an error, and this pull request was enough to get rid of it.