### PR TITLE
fix: stats graphs alignments

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,7 @@
     "std/": "https://deno.land/std@0.188.0/",
     "stripe": "https://esm.sh/stripe@12.6.0",
     "feed": "https://esm.sh/feed@4.2.2",
-    "fresh_charts/": "https://deno.land/x/fresh_charts@0.2.1/",
+    "fresh_charts/": "https://raw.githubusercontent.com/kt3k/fresh_charts/configurable-svg-style/",
     "kv_oauth": "https://deno.land/x/deno_kv_oauth@v0.2.5/mod.ts",
     "@twind/core": "https://esm.sh/@twind/core@1.1.3"
   }

--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,7 @@
     "std/": "https://deno.land/std@0.188.0/",
     "stripe": "https://esm.sh/stripe@12.6.0",
     "feed": "https://esm.sh/feed@4.2.2",
-    "fresh_charts/": "https://raw.githubusercontent.com/kt3k/fresh_charts/configurable-svg-style/",
+    "fresh_charts/": "https://deno.land/x/fresh_charts@0.2.2/",
     "kv_oauth": "https://deno.land/x/deno_kv_oauth@v0.2.5/mod.ts",
     "@twind/core": "https://esm.sh/@twind/core@1.1.3"
   }

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -50,13 +50,14 @@ function LineChart(
   const total = data.reduce((value, currentValue) => currentValue + value, 0);
 
   return (
-    <div class="py-4 resize lg:chart w-full">
+    <div class="py-4 resize lg:chart">
       <div class="py-4 text-center">
         <h3>{props.title}</h3>
         <p class="font-bold">{total}</p>
       </div>
       <div class="overflow-auto">
         <Chart
+          svgClass="m-auto"
           type="line"
           options={{
             maintainAspectRatio: false,


### PR DESCRIPTION
This change horizontally aligns graphs to the centre of the page on desktop screens.

This is a follow-up to #319
Depends on https://github.com/denoland/fresh_charts/pull/14

CC @kt3k 