### PR TITLE
refactor: stats charts improvements and simplifications

### DIFF
--- a/islands/Chart.tsx
+++ b/islands/Chart.tsx
@@ -5,7 +5,7 @@ import {
   type ChartType,
   type DefaultDataPoint,
 } from "chart.js";
-import { type MutableRef, useEffect, useRef } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import type { JSX } from "preact";
 
 type ChartOptions<
@@ -28,7 +28,6 @@ function useChart<
   Data = DefaultDataPoint<Type>,
   Label = unknown,
 >(options: ChartOptions<Type, Data, Label>) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const chartRef = useRef<ChartJS<Type, Data, Label> | null>(null);
 
@@ -46,38 +45,13 @@ function useChart<
     };
   }, [options]);
 
-  return { canvasRef, chartRef, containerRef };
+  return { canvasRef, chartRef };
 }
 
-function useResizeObserver<T extends HTMLElement | null>(
-  ref: MutableRef<T>,
-  callback: ResizeObserverCallback,
+export default function Chart<Type extends ChartType>(
+  options: ChartProps<Type>,
 ) {
-  useEffect(() => {
-    if (!ref.current) return;
-    const observer = new ResizeObserver(callback);
-    observer.observe(ref.current as HTMLElement);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [ref]);
-}
-
-export default function Chart<
-  Type extends ChartType,
->(
-  { canvas, container, ...options }: ChartProps<Type>,
-) {
-  const { canvasRef, chartRef, containerRef } = useChart(options);
-
-  useResizeObserver(containerRef, (entries) => {
-    if (!Array.isArray(entries)) return;
-    const entry = entries?.[0];
-    if (!entry) return;
-
-    chartRef.current?.resize(entry.contentRect.width, entry.contentRect.height);
-  });
+  const { canvasRef, chartRef } = useChart(options);
 
   useEffect(() => {
     chartRef.current?.render();
@@ -85,7 +59,6 @@ export default function Chart<
 
   return (
     <canvas
-      {...canvas}
       ref={canvasRef}
     />
   );

--- a/islands/Chart.tsx
+++ b/islands/Chart.tsx
@@ -20,7 +20,6 @@ type ChartProps<
   Label = unknown,
 > = ChartOptions<Type, Data, Label> & {
   canvas?: JSX.HTMLAttributes<HTMLCanvasElement>;
-  container?: JSX.HTMLAttributes<HTMLDivElement>;
 };
 
 function useChart<

--- a/islands/Chart.tsx
+++ b/islands/Chart.tsx
@@ -84,14 +84,9 @@ export default function Chart<
   }, []);
 
   return (
-    <div
-      {...container}
-      ref={containerRef}
-    >
-      <canvas
-        {...canvas}
-        ref={canvasRef}
-      />
-    </div>
+    <canvas
+      {...canvas}
+      ref={canvasRef}
+    />
   );
 }

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -96,7 +96,7 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
               y: {
                 beginAtZero: true,
                 grid: { display: false },
-                ticks: { stepSize: 1 },
+                ticks: { precision: 0 },
               },
             },
           }}

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -81,6 +81,7 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
       <Chart
         type="line"
         options={{
+          maintainAspectRatio: false,
           plugins: {
             title: {
               display: true,

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -44,30 +44,30 @@ export const handler: Handlers<StatsPageData, State> = {
 };
 
 export default function StatsPage(props: PageProps<StatsPageData>) {
-  const charts = [
+  const datasets = [
     {
-      title: "Site visits",
-      values: props.data.visitsCounts,
-      color: "#be185d",
+      label: "Site visits",
+      data: props.data.visitsCounts,
+      borderColor: "#be185d",
     },
     {
-      title: "Users created",
-      values: props.data.usersCounts,
-      color: "#e85d04",
+      label: "Users created",
+      data: props.data.usersCounts,
+      borderColor: "#e85d04",
     },
     {
-      title: "Items created",
-      values: props.data.itemsCounts,
-      color: "#219ebc",
+      label: "Items created",
+      data: props.data.itemsCounts,
+      borderColor: "#219ebc",
     },
     {
-      title: "Votes",
-      values: props.data.votesCounts,
-      color: "#4338ca",
+      label: "Votes",
+      data: props.data.votesCounts,
+      borderColor: "#4338ca",
     },
   ];
 
-  const x = props.data.dates.map((date) =>
+  const labels = props.data.dates.map((date) =>
     new Date(date).toLocaleDateString("en-us", {
       month: "short",
       day: "numeric",
@@ -75,58 +75,40 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
   );
 
   return (
-    <main class="flex-1 p-4 grid gap-12 md:grid-cols-2">
-      {charts.map(({ color, title, values }) => {
-        const data = values.map((value) => Number(value));
-        const total = data.reduce(
-          (value, currentValue) => currentValue + value,
-          0,
-        );
-
-        return (
-          <div class="py-4">
-            <div class="text-center">
-              <h3>{title}</h3>
-              <p class="font-bold">{total}</p>
-            </div>
-            <Chart
-              container={{
-                class: "aspect-[2/1] mx-auto relative max-w-[100vw]",
-              }}
-              type="line"
-              options={{
-                plugins: {
-                  legend: { display: false },
-                },
-                interaction: {
-                  intersect: false,
-                },
-                scales: {
-                  x: {
-                    grid: { display: false },
-                  },
-                  y: {
-                    beginAtZero: true,
-                    grid: { display: false },
-                    max: Math.ceil(Math.max(...data) * 1.1),
-                    ticks: { stepSize: 1 },
-                  },
-                },
-              }}
-              data={{
-                labels: x,
-                datasets: [{
-                  label: title,
-                  data,
-                  borderColor: color,
-                  pointRadius: 0,
-                  cubicInterpolationMode: "monotone",
-                }],
-              }}
-            />
-          </div>
-        );
-      })}
+    <main class="flex-1 p-4 aspect-[2/1] mx-auto relative w-full">
+      <Chart
+        type="line"
+        options={{
+          plugins: {
+            title: {
+              display: true,
+              text: "Daily counts",
+            },
+          },
+          interaction: {
+            intersect: false,
+            mode: "index",
+          },
+          scales: {
+            x: {
+              grid: { display: false },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { display: false },
+            },
+          },
+        }}
+        data={{
+          labels,
+          datasets: datasets.map((dataset) => ({
+            ...dataset,
+            data: dataset.data.map((value) => Number(value)),
+            pointRadius: 0,
+            cubicInterpolationMode: "monotone",
+          })),
+        }}
+      />
     </main>
   );
 }

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -7,10 +7,10 @@ import { getDatesSince, getManyMetrics } from "@/utils/db.ts";
 
 interface StatsPageData extends State {
   dates: Date[];
-  visitsCounts: bigint[];
-  usersCounts: bigint[];
-  itemsCounts: bigint[];
-  votesCounts: bigint[];
+  visitsCounts: number[];
+  usersCounts: number[];
+  itemsCounts: number[];
+  votesCounts: number[];
 }
 
 export const handler: Handlers<StatsPageData, State> = {
@@ -35,10 +35,10 @@ export const handler: Handlers<StatsPageData, State> = {
     return ctx.render({
       ...ctx.state,
       dates,
-      visitsCounts,
-      usersCounts,
-      itemsCounts,
-      votesCounts,
+      visitsCounts: visitsCounts.map(Number),
+      usersCounts: usersCounts.map(Number),
+      itemsCounts: itemsCounts.map(Number),
+      votesCounts: votesCounts.map(Number),
     });
   },
 };
@@ -67,6 +67,8 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
     },
   ];
 
+  const max = Math.max(...datasets[0].data);
+
   const labels = props.data.dates.map((date) =>
     new Date(date).toLocaleDateString("en-us", {
       month: "short",
@@ -91,6 +93,7 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
           },
           scales: {
             x: {
+              max,
               grid: { display: false },
             },
             y: {
@@ -103,7 +106,6 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
           labels,
           datasets: datasets.map((dataset) => ({
             ...dataset,
-            data: dataset.data.map((value) => Number(value)),
             pointRadius: 0,
             cubicInterpolationMode: "monotone",
           })),

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -77,41 +77,39 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
   );
 
   return (
-    <main class="flex-1 p-4 relative">
-      <Chart
-        type="line"
-        options={{
-          maintainAspectRatio: false,
-          plugins: {
-            title: {
-              display: true,
-              text: "Daily counts",
+    <main class="flex-1 p-4 flex flex-col">
+      <h1 class="text-3xl font-bold">Stats</h1>
+      <div class="flex-1 relative">
+        <Chart
+          type="line"
+          options={{
+            maintainAspectRatio: false,
+            interaction: {
+              intersect: false,
+              mode: "index",
             },
-          },
-          interaction: {
-            intersect: false,
-            mode: "index",
-          },
-          scales: {
-            x: {
-              max,
-              grid: { display: false },
+            scales: {
+              x: {
+                max,
+                grid: { display: false },
+              },
+              y: {
+                beginAtZero: true,
+                grid: { display: false },
+                ticks: { stepSize: 1 },
+              },
             },
-            y: {
-              beginAtZero: true,
-              grid: { display: false },
-            },
-          },
-        }}
-        data={{
-          labels,
-          datasets: datasets.map((dataset) => ({
-            ...dataset,
-            pointRadius: 0,
-            cubicInterpolationMode: "monotone",
-          })),
-        }}
-      />
+          }}
+          data={{
+            labels,
+            datasets: datasets.map((dataset) => ({
+              ...dataset,
+              pointRadius: 0,
+              cubicInterpolationMode: "monotone",
+            })),
+          }}
+        />
+      </div>
     </main>
   );
 }

--- a/routes/stats.tsx
+++ b/routes/stats.tsx
@@ -77,7 +77,7 @@ export default function StatsPage(props: PageProps<StatsPageData>) {
   );
 
   return (
-    <main class="flex-1 p-4 aspect-[2/1] mx-auto relative w-full">
+    <main class="flex-1 p-4 relative">
       <Chart
         type="line"
         options={{


### PR DESCRIPTION
This change:
* Simplifies the `<Chart />` island to only return the `<canvas>` element. Parent styling can be done separately.
* Combines 4 charts into a single, large, interactive chart that can hide/show datasets.
* Adds enables the [`index`](https://www.chartjs.org/docs/latest/samples/tooltip/content.html) interaction mode, which shows the values for all shown datasets for a given date.
* Removes configuration and code which may not be needed.
* Disables `maintainAspectRatio`.

Please review by checking deployment, @mbhrznr.