### PR TITLE
fix: target `es2022` for `Chart.js` import and upgrade to v4.3.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -30,7 +30,7 @@
     "feed": "https://esm.sh/feed@4.2.2",
     "kv_oauth": "https://deno.land/x/deno_kv_oauth@v0.2.5/mod.ts",
     "@twind/core": "https://esm.sh/@twind/core@1.1.3",
-    "chart.js": "https://esm.sh/stable/chart.js@4.0.1/auto"
+    "chart.js": "https://esm.sh/stable/chart.js@4.3.0/auto?target=es2022"
   },
   "exclude": [
     "cov/"


### PR DESCRIPTION
I just realised that this might be the cause of our woes. Previously, the target would've been `deno` as islands are built server-side. Checkout "ESBuild Options" in https://esm.sh/#docs 

Closes #354
Supercedes #355