### PR TITLE
feat: `<GitHubAvatarImg />`

### DIFF
--- a/components/GitHubAvatarImg.tsx
+++ b/components/GitHubAvatarImg.tsx
@@ -1,0 +1,20 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+export default function GitHubAvatarImg(
+  props: { login: string; size: number; class?: string },
+) {
+  return (
+    <img
+      height={props.size}
+      width={props.size}
+      src={`https://avatars.githubusercontent.com/${props.login}?s=${
+        props.size * 2
+      }`}
+      alt={`GitHub avatar of ${props.login}`}
+      class={`rounded-full inline-block aspect-square h-[${props.size}px] w-[${props.size}px] ${
+        props.class ?? ""
+      }`}
+      crossOrigin="anonymous"
+      loading="lazy"
+    />
+  );
+}

--- a/components/GitHubAvatarImg.tsx
+++ b/components/GitHubAvatarImg.tsx
@@ -1,11 +1,18 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export default function GitHubAvatarImg(
-  props: { login: string; size: number; class?: string },
+  props: {
+    // AKA GitHub user's username.
+    login: string;
+    // Defines the rended height and width of the image, in pixels.
+    size: number;
+    class?: string;
+  },
 ) {
   return (
     <img
       height={props.size}
       width={props.size}
+      // Intrinsic size is 2x rendered size for Retina displays
       src={`https://avatars.githubusercontent.com/${props.login}?s=${
         props.size * 2
       }`}

--- a/components/UserPostedAt.tsx
+++ b/components/UserPostedAt.tsx
@@ -1,20 +1,17 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { User } from "@/utils/db.ts";
 import { timeAgo } from "@/utils/display.ts";
+import GitHubAvatarImg from "@/components/GitHubAvatarImg.tsx";
 
 export default function UserPostedAt(
   props: { user: User; createdAt: Date },
 ) {
   return (
     <p class="text-gray-500">
-      <img
-        // Resize the avatar image to be 36x36 px
-        // Although display size is 24x24, lighthouse complains about low resolution if the image is 24x24
-        src={props.user.avatarUrl + "&s=36"}
-        alt={props.user.login}
-        crossOrigin="anonymous"
-        class="h-6 w-auto rounded-full inline-block mr-2"
-        loading="lazy"
+      <GitHubAvatarImg
+        login={props.user.login}
+        size={24}
+        class="mr-2"
       />
       <a class="hover:underline" href={`/user/${props.user.login}`}>
         {props.user.login}

--- a/routes/account/index.tsx
+++ b/routes/account/index.tsx
@@ -5,6 +5,7 @@ import { BUTTON_STYLES } from "@/utils/constants.ts";
 import { ComponentChild } from "preact";
 import { stripe } from "@/utils/payments.ts";
 import Head from "@/components/Head.tsx";
+import GitHubAvatarImg from "@/components/GitHubAvatarImg.tsx";
 
 export const handler: Handlers<AccountState, AccountState> = {
   GET(_request, ctx) {
@@ -41,11 +42,10 @@ export default function AccountPage(props: PageProps<AccountState>) {
     <>
       <Head title="Account" href={props.url.href} />
       <main class="max-w-lg m-auto w-full flex-1 p-4 flex flex-col justify-center">
-        <img
-          src={props.data.user?.avatarUrl}
-          alt="User Avatar"
-          crossOrigin="anonymous"
-          class="max-w-[50%] self-center rounded-full aspect-square mb-4 md:mb-6"
+        <GitHubAvatarImg
+          login={props.data.user.login}
+          size={240}
+          class="m-auto"
         />
         <ul>
           <Row

--- a/routes/callback.ts
+++ b/routes/callback.ts
@@ -18,7 +18,6 @@ import {
 interface GitHubUser {
   id: number;
   login: string;
-  avatar_url: string;
   email: string;
 }
 
@@ -56,7 +55,6 @@ export default async function CallbackPage(req: Request) {
     const user: User = {
       id: githubUser.id.toString(),
       login: githubUser.login,
-      avatarUrl: githubUser.avatar_url,
       stripeCustomerId,
       sessionId,
       ...newUserProps(),

--- a/routes/user/[username].tsx
+++ b/routes/user/[username].tsx
@@ -1,6 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { Handlers, PageProps } from "$fresh/server.ts";
-import { ComponentChild } from "preact";
 import type { State } from "@/routes/_middleware.ts";
 import ItemSummary from "@/components/ItemSummary.tsx";
 import { calcLastPage, calcPageNum, PAGE_LENGTH } from "@/utils/pagination.ts";
@@ -17,6 +16,7 @@ import { pluralize } from "@/utils/display.ts";
 import { GitHub } from "@/components/Icons.tsx";
 import { LINK_STYLES } from "@/utils/constants.ts";
 import Head from "@/components/Head.tsx";
+import GitHubAvatarImg from "@/components/GitHubAvatarImg.tsx";
 
 export interface UserData extends State {
   user: User;
@@ -63,34 +63,28 @@ export const handler: Handlers<UserData, State> = {
   },
 };
 
-interface RowProps {
-  title: string;
-  children?: ComponentChild;
-  text: string;
-  img?: string;
-}
-
-function Row(props: RowProps) {
+function Profile(props: { login: string; itemsCount: number }) {
   return (
     <div class="flex flex-wrap py-8">
-      {props.img && (
-        <img
-          height="48"
-          width="48"
-          src={props.img}
-          alt="user avatar"
-          class="rounded-full"
-        />
-      )}
+      <GitHubAvatarImg login={props.login} size={48} />
       <div class="px-4">
         <div class="flex flex-wrap justify-between">
           <span>
-            <strong>{props.title}</strong>
+            <strong>{props.login}</strong>
           </span>
-          {props.children && <span class="ml-2">{props.children}</span>}
+          <span class="ml-2">
+            <a
+              href={`https://github.com/${props.login}`}
+              aria-label={`${props.login}'s GitHub profile`}
+              class={LINK_STYLES}
+              target="_blank"
+            >
+              <GitHub class="text-sm w-6" />
+            </a>
+          </span>
         </div>
         <p>
-          {props.text}
+          {pluralize(props.itemsCount, "submission")}
         </p>
       </div>
     </div>
@@ -102,21 +96,10 @@ export default function UserPage(props: PageProps<UserData>) {
     <>
       <Head title={props.data.user.login} href={props.url.href} />
       <main class="flex-1 p-4">
-        <Row
-          title={props.data.user.login}
-          text={pluralize(props.data.itemsCount, "submission")}
-          img={props.data.user.avatarUrl}
-        >
-          <a
-            href={`https://github.com/${props.data.user.login}`}
-            alt={`to ${props.data.user.login}'s GitHub profile`}
-            aria-label={`${props.data.user.login}'s GitHub profile`}
-            class={LINK_STYLES}
-            target="_blank"
-          >
-            <GitHub class="text-sm w-6" />
-          </a>
-        </Row>
+        <Profile
+          login={props.data.user.login}
+          itemsCount={props.data.itemsCount}
+        />
         {props.data.items.map((item, index) => (
           <ItemSummary
             item={item}

--- a/tools/migrate_kv.ts
+++ b/tools/migrate_kv.ts
@@ -1,32 +1,11 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import {
-  deleteComment,
-  deleteItem,
-  getCommentsByItem,
-  getItem,
-  kv,
-} from "@/utils/db.ts";
+import { kv, updateUser, User } from "@/utils/db.ts";
 
 export async function migrateKv() {
-  const itemIds = [
-    "3064e1e4-1934-461a-adbe-e6e2a30f73ae",
-    "eace50d0-dc57-4dd1-a8f9-0f59535d48c9",
-    "ff47e677-e9d6-4e7f-8592-acd5c7688c8a",
-    "c7096c2b-3df0-4d80-a996-0d247be4aee6",
-    "6e268bb3-72c4-4ad7-8102-44aed8809feb",
-    "acc8822c-69ec-475e-9f60-4a00213d9a60",
-    "425ad977-8f3f-4966-a262-2aff44572686",
-  ];
+  const iter = kv.list<User>({ prefix: ["users"] });
   const promises = [];
-  for (const itemId of itemIds) {
-    const item = await getItem(itemId);
-    if (item === null) break;
-    promises.push(deleteItem(item));
-
-    const comments = await getCommentsByItem(itemId);
-    for (const comment of comments) {
-      promises.push(deleteComment(comment));
-    }
+  for await (const entry of iter) {
+    promises.push(updateUser(entry.value));
   }
   await Promise.all(promises);
 }

--- a/tools/seed_submissions.ts
+++ b/tools/seed_submissions.ts
@@ -98,7 +98,6 @@ async function main(limit = 20) {
       const user: User = {
         id, // id must match userId for post
         login: id,
-        avatarUrl: "https://www.gravatar.com/avatar/?d=mp&s=64",
         stripeCustomerId: crypto.randomUUID(), // unique per userId
         sessionId: crypto.randomUUID(), // unique per userId
         ...newUserProps(),

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -431,7 +431,6 @@ export async function getVotedItemsByUser(userId: string) {
 export interface User {
   id: string;
   login: string;
-  avatarUrl: string;
   sessionId: string;
   stripeCustomerId?: string;
   // The below properties can be automatically generated upon comment creation
@@ -454,7 +453,6 @@ export function newUserProps(): Pick<User, "isSubscribed"> {
  * const user = {
  *   id: "id",
  *   login: "login",
- *   avatarUrl: "https://example.com/avatar-url",
  *   sessionId: "sessionId",
  *   ...newUserProps(),
  * };

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -72,7 +72,6 @@ function genNewUser(): User {
   return {
     id: crypto.randomUUID(),
     login: crypto.randomUUID(),
-    avatarUrl: `http://${crypto.randomUUID()}`,
     sessionId: crypto.randomUUID(),
     stripeCustomerId: crypto.randomUUID(),
     ...newUserProps(),


### PR DESCRIPTION
This change adds a new size-adjustable and class-customisable `<GitHubAvatarImg />`. It's dynamically generated using the user's login (AKA username). As a result, the `avatarUrl` property from the `User` interface has been removed.

The migration script updates all user objects without the `avatarUrl` property.

Please review, if you'd like, @brunocorrea23.