### PR TITLE
feat: users can delete own item

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -151,3 +151,27 @@ export function Cross(props: JSX.SVGAttributes<SVGSVGElement>) {
     </svg>
   );
 }
+
+export function Trash(props: JSX.SVGAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+      <path d="M4 7l16 0"></path>
+      <path d="M10 11l0 6"></path>
+      <path d="M14 11l0 6"></path>
+      <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12"></path>
+      <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3"></path>
+    </svg>
+  );
+}


### PR DESCRIPTION
Closes #375 

Two questions:
- Is this too much a work around? (this = handling two diff actions on a rounds POST handler. Should we create an island+api route to handle the item deletion? not sure about the best practice here)
- Today the item deletion code in db.ts does not handle the deletion of votes or comments associated with that item. Should it?