### PR TITLE
refactor: move premium user badge

### DIFF
--- a/components/ItemSummary.tsx
+++ b/components/ItemSummary.tsx
@@ -32,7 +32,10 @@ export default function ItemSummary(props: ItemSummaryProps) {
             {new URL(props.item.url).host} ↗
           </a>
         </p>
-        <UserPostedAt user={props.user} createdAt={props.item.createdAt} />
+        <UserPostedAt
+          userLogin={props.user.login}
+          createdAt={props.item.createdAt}
+        />
       </div>
     </div>
   );

--- a/components/UserPostedAt.tsx
+++ b/components/UserPostedAt.tsx
@@ -1,24 +1,20 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import type { User } from "@/utils/db.ts";
 import { timeAgo } from "@/utils/display.ts";
 import GitHubAvatarImg from "@/components/GitHubAvatarImg.tsx";
 
 export default function UserPostedAt(
-  props: { user: User; createdAt: Date },
+  props: { userLogin: string; createdAt: Date },
 ) {
   return (
     <p class="text-gray-500">
       <GitHubAvatarImg
-        login={props.user.login}
+        login={props.userLogin}
         size={24}
         class="mr-2"
       />
-      <a class="hover:underline" href={`/user/${props.user.login}`}>
-        {props.user.login}
+      <a class="hover:underline" href={`/user/${props.userLogin}`}>
+        {props.userLogin}
       </a>{" "}
-      {props.user.isSubscribed && (
-        <span title="Deno Hunt premium user">🦕{" "}</span>
-      )}
       {timeAgo(new Date(props.createdAt))} ago
     </p>
   );

--- a/routes/item/[id].tsx
+++ b/routes/item/[id].tsx
@@ -136,7 +136,7 @@ function CommentSummary(
   return (
     <div class="py-4">
       <UserPostedAt
-        user={props.user}
+        userLogin={props.user.login}
         createdAt={props.comment.createdAt}
       />
       <p>{props.comment.text}</p>

--- a/routes/user/[login].tsx
+++ b/routes/user/[login].tsx
@@ -62,16 +62,21 @@ export const handler: Handlers<UserData, State> = {
   },
 };
 
-function Profile(props: { login: string; itemsCount: number }) {
+function Profile(
+  props: { login: string; itemsCount: number; isSubscribed: boolean },
+) {
   return (
     <div class="flex flex-wrap py-8">
       <GitHubAvatarImg login={props.login} size={48} />
       <div class="px-4">
-        <div class="flex flex-wrap justify-between">
+        <div class="flex gap-x-2">
           <span>
             <strong>{props.login}</strong>
           </span>
-          <span class="ml-2">
+          {props.isSubscribed && (
+            <span title="Deno Hunt premium user">🦕{" "}</span>
+          )}
+          <span>
             <a
               href={`https://github.com/${props.login}`}
               aria-label={`${props.login}'s GitHub profile`}
@@ -96,6 +101,7 @@ export default function UserPage(props: PageProps<UserData>) {
       <Head title={props.data.user.login} href={props.url.href} />
       <main class="flex-1 p-4">
         <Profile
+          isSubscribed={props.data.user.isSubscribed}
           login={props.data.user.login}
           itemsCount={props.data.itemsCount}
         />


### PR DESCRIPTION
This change moved the premium badge from being shown in item and comment rows to only on user pages. This is part of a move towards removing the `id` field from the `User` interface.