### PR TITLE
refactor: use `userLogin` property in `Comment` interface

### DIFF
--- a/routes/item/[id].tsx
+++ b/routes/item/[id].tsx
@@ -12,7 +12,6 @@ import {
   getAreVotedBySessionId,
   getCommentsByItem,
   getItem,
-  getManyUsers,
   getUser,
   getUserBySession,
   type Item,
@@ -29,7 +28,6 @@ interface ItemPageData extends State {
   user: User;
   item: Item;
   comments: Comment[];
-  commentsUsers: User[];
   isVoted: boolean;
   lastPage: number;
 }
@@ -51,9 +49,6 @@ export const handler: Handlers<ItemPageData, State> = {
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
       .slice((pageNum - 1) * PAGE_LENGTH, pageNum * PAGE_LENGTH);
 
-    const commentsUsers = await getManyUsers(
-      comments.map((comment) => comment.userId),
-    );
     const user = await getUser(item.userId);
 
     const [isVoted] = await getAreVotedBySessionId(
@@ -68,7 +63,6 @@ export const handler: Handlers<ItemPageData, State> = {
       item,
       comments,
       user: user!,
-      commentsUsers,
       isVoted,
       lastPage,
     });
@@ -94,7 +88,7 @@ export const handler: Handlers<ItemPageData, State> = {
     }
 
     const comment: Comment = {
-      userId: user.id,
+      userLogin: user.login,
       itemId: itemId,
       text,
       ...newCommentProps(),
@@ -130,16 +124,14 @@ function CommentInput() {
   );
 }
 
-function CommentSummary(
-  props: { user: User; comment: Comment },
-) {
+function CommentSummary(comment: Comment) {
   return (
     <div class="py-4">
       <UserPostedAt
-        userLogin={props.user.login}
-        createdAt={props.comment.createdAt}
+        userLogin={comment.userLogin}
+        createdAt={comment.createdAt}
       />
-      <p>{props.comment.text}</p>
+      <p>{comment.text}</p>
     </div>
   );
 }
@@ -156,10 +148,9 @@ export default function ItemPage(props: PageProps<ItemPageData>) {
         />
         <CommentInput />
         <div>
-          {props.data.comments.map((comment, index) => (
+          {props.data.comments.map((comment) => (
             <CommentSummary
-              user={props.data.commentsUsers[index]}
-              comment={comment}
+              {...comment}
             />
           ))}
         </div>

--- a/tools/migrate_kv.ts
+++ b/tools/migrate_kv.ts
@@ -1,13 +1,41 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { kv, updateUser, User } from "@/utils/db.ts";
+import {
+  type Comment,
+  createComment,
+  deleteComment,
+  getUser,
+  kv,
+} from "@/utils/db.ts";
+
+type OldComment = Omit<Comment, "userLogin"> & { userId: string };
+
+async function migrateComment(oldComment: OldComment) {
+  const user = await getUser(oldComment.userId);
+  if (user === null) {
+    throw new Deno.errors.NotFound(
+      `User with ID not found: ${oldComment.userId}`,
+    );
+  }
+  // @ts-ignore Trust me
+  await deleteComment(oldComment);
+  await createComment({
+    userLogin: user.login,
+    id: oldComment.id,
+    itemId: oldComment.itemId,
+    text: oldComment.text,
+    createdAt: oldComment.createdAt,
+  });
+}
 
 export async function migrateKv() {
-  const iter = kv.list<User>({ prefix: ["users"] });
+  const iter = kv.list<OldComment | Comment>({ prefix: ["comments_by_item"] });
   const promises = [];
   for await (const entry of iter) {
-    promises.push(updateUser(entry.value));
+    // @ts-ignore Trust me
+    if (entry.value.userId) promises.push(migrateComment(entry.value));
   }
   await Promise.all(promises);
+  console.log("KV migration complete.");
 }
 
 if (import.meta.main) {

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -280,7 +280,7 @@ export async function ifUserHasNotifications(userId: string) {
 
 // Comment
 export interface Comment {
-  userId: string;
+  userLogin: string;
   itemId: string;
   text: string;
   // The below properties can be automatically generated upon comment creation

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -51,7 +51,7 @@ import { DAY } from "std/datetime/constants.ts";
 function genNewComment(comment?: Partial<Comment>): Comment {
   return {
     itemId: crypto.randomUUID(),
-    userId: crypto.randomUUID(),
+    userLogin: crypto.randomUUID(),
     text: crypto.randomUUID(),
     ...newCommentProps(),
     ...comment,


### PR DESCRIPTION
This change replaces the `userId` property on the `Comment` interface with `userLogin`. The benefit of this is that we eliminate KV-flavoured joins from DB logic, making it much more straightforward.

This is part of a series of PRs moving towards removing the `User["id"]` property from the codebase. Reviewers, please pay close attention to the migration script, which migrates the old comment interface to the new one.

CC @brunocorrea23, @mbhrznr