### PR TITLE
refactor: remove `user.id` use and rework vote logic

### DIFF
--- a/components/ItemSummary.tsx
+++ b/components/ItemSummary.tsx
@@ -5,7 +5,6 @@ import UserPostedAt from "./UserPostedAt.tsx";
 
 export interface ItemSummaryProps {
   item: Item;
-  user: User;
   isVoted: boolean;
 }
 
@@ -33,7 +32,7 @@ export default function ItemSummary(props: ItemSummaryProps) {
           </a>
         </p>
         <UserPostedAt
-          userLogin={props.user.login}
+          userLogin={props.item.userLogin}
           createdAt={props.item.createdAt}
         />
       </div>

--- a/routes/_404.tsx
+++ b/routes/_404.tsx
@@ -1,10 +1,10 @@
-import { HEADING_WITH_MARGIN_STYLES, LINK_STYLES } from "@/utils/constants.ts";
+import { HEADING_STYLES, LINK_STYLES } from "@/utils/constants.ts";
 
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export default function NotFoundPage() {
   return (
     <main class="flex-1 p-4 flex flex-col justify-center text-center">
-      <h1 class={HEADING_WITH_MARGIN_STYLES}>Page not found</h1>
+      <h1 class={HEADING_STYLES}>Page not found</h1>
       <p>
         <a href="/" class={LINK_STYLES}>Return home ›</a>
       </p>

--- a/routes/_500.tsx
+++ b/routes/_500.tsx
@@ -1,14 +1,14 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { ErrorPageProps } from "$fresh/server.ts";
-import { HEADING_WITH_MARGIN_STYLES, LINK_STYLES } from "@/utils/constants.ts";
+import { HEADING_STYLES, LINK_STYLES } from "@/utils/constants.ts";
 
 export default function Error500Page(props: ErrorPageProps) {
   return (
-    <main class="flex flex-col justify-center p-4 text-center space-y-4">
-      <h1 class={HEADING_WITH_MARGIN_STYLES}>Server error</h1>
+    <main class="flex flex-1 flex-col justify-center p-4 text-center space-y-4">
+      <h1 class={HEADING_STYLES}>Server error</h1>
       <p>500 internal error: {(props.error as Error).message}</p>
       <p>
-        <a href="/" class={LINK_STYLES}>Return home</a>
+        <a href="/" class={LINK_STYLES}>Return home ›</a>
       </p>
     </main>
   );

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -30,7 +30,7 @@ async function setState(req: Request, ctx: MiddlewareHandlerContext<State>) {
 
   if (sessionId) {
     const user = await getUserBySession(sessionId);
-    ctx.state.hasNotifications = await ifUserHasNotifications(user!.id);
+    ctx.state.hasNotifications = await ifUserHasNotifications(user!.login);
   }
 
   return await ctx.next();

--- a/routes/api/vote.ts
+++ b/routes/api/vote.ts
@@ -43,9 +43,9 @@ async function sharedHandler(
       status = 201;
       await createVote(vote);
 
-      if (item.userId !== user.id) {
+      if (item.userLogin !== user.login) {
         const notification: Notification = {
-          userId: item.userId,
+          userLogin: item.userLogin,
           type: "vote",
           text: `${user.login} upvoted your post: ${item.title}`,
           originUrl: `/item/${itemId}`,

--- a/routes/api/vote.ts
+++ b/routes/api/vote.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { HandlerContext, Handlers, PageProps } from "$fresh/server.ts";
 import type { State } from "@/routes/_middleware.ts";
-import { createVote, deleteVote, getItem } from "@/utils/db.ts";
+import { createVote, deleteVote, getItem, newVoteProps } from "@/utils/db.ts";
 import {
   createNotification,
   getUserBySession,
@@ -18,7 +18,6 @@ async function sharedHandler(
   }
 
   const itemId = new URL(req.url).searchParams.get("item_id");
-
   if (!itemId) {
     return new Response(null, { status: 400 });
   }
@@ -27,12 +26,15 @@ async function sharedHandler(
     getItem(itemId),
     getUserBySession(ctx.state.sessionId),
   ]);
-
   if (item === null || user === null) {
     return new Response(null, { status: 404 });
   }
 
-  const vote = { item, user };
+  const vote = {
+    item,
+    userLogin: user.login,
+    ...newVoteProps(),
+  };
   let status;
   switch (req.method) {
     case "DELETE":

--- a/routes/callback.ts
+++ b/routes/callback.ts
@@ -16,7 +16,6 @@ import {
 } from "@/utils/redirect.ts";
 
 interface GitHubUser {
-  id: number;
   login: string;
   email: string;
 }
@@ -43,7 +42,7 @@ export default async function CallbackPage(req: Request) {
 
   const githubUser = await getGitHubUser(accessToken);
 
-  const user = await getUser(githubUser.id.toString());
+  const user = await getUser(githubUser.login);
   if (!user) {
     let stripeCustomerId = undefined;
     if (stripe) {
@@ -53,7 +52,6 @@ export default async function CallbackPage(req: Request) {
       stripeCustomerId = customer.id;
     }
     const user: User = {
-      id: githubUser.id.toString(),
       login: githubUser.login,
       stripeCustomerId,
       sessionId,

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -10,7 +10,6 @@ import {
   getAreVotedBySessionId,
   getItemsSince,
   type Item,
-  type User,
 } from "@/utils/db.ts";
 import { DAY, WEEK } from "std/datetime/constants.ts";
 import { getToggledStyles } from "@/utils/display.ts";

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -9,7 +9,6 @@ import {
   getAllItems,
   getAreVotedBySessionId,
   getItemsSince,
-  getManyUsers,
   type Item,
   type User,
 } from "@/utils/db.ts";
@@ -19,7 +18,6 @@ import { ACTIVE_LINK_STYLES, LINK_STYLES } from "@/utils/constants.ts";
 import Head from "@/components/Head.tsx";
 
 interface HomePageData extends State {
-  itemsUsers: User[];
   items: Item[];
   lastPage: number;
   areVoted: boolean[];
@@ -47,15 +45,13 @@ export const handler: Handlers<HomePageData, State> = {
       .toSorted(compareScore)
       .slice((pageNum - 1) * PAGE_LENGTH, pageNum * PAGE_LENGTH);
 
-    const itemsUsers = await getManyUsers(items.map((item) => item.userId));
-
     const areVoted = await getAreVotedBySessionId(
       items,
       ctx.state.sessionId,
     );
     const lastPage = calcLastPage(allItems.length, PAGE_LENGTH);
 
-    return ctx.render({ ...ctx.state, items, itemsUsers, areVoted, lastPage });
+    return ctx.render({ ...ctx.state, items, areVoted, lastPage });
   },
 };
 
@@ -108,7 +104,6 @@ export default function HomePage(props: PageProps<HomePageData>) {
           <ItemSummary
             item={item}
             isVoted={props.data.areVoted[index]}
-            user={props.data.itemsUsers[index]}
           />
         ))}
         {props.data.lastPage > 1 && (

--- a/routes/item/[id].tsx
+++ b/routes/item/[id].tsx
@@ -49,7 +49,7 @@ export const handler: Handlers<ItemPageData, State> = {
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
       .slice((pageNum - 1) * PAGE_LENGTH, pageNum * PAGE_LENGTH);
 
-    const user = await getUser(item.userId);
+    const user = await getUser(item.userLogin);
 
     const [isVoted] = await getAreVotedBySessionId(
       [item],
@@ -95,9 +95,9 @@ export const handler: Handlers<ItemPageData, State> = {
     };
     await createComment(comment);
 
-    if (item.userId !== user.id) {
+    if (item.userLogin !== user.login) {
       const notification: Notification = {
-        userId: item.userId,
+        userLogin: item.userLogin,
         type: "comment",
         text: `${user.login} commented on your post: ${item.title}`,
         originUrl: `/item/${itemId}`,
@@ -144,7 +144,6 @@ export default function ItemPage(props: PageProps<ItemPageData>) {
         <ItemSummary
           item={props.data.item}
           isVoted={props.data.isVoted}
-          user={props.data.user}
         />
         <CommentInput />
         <div>

--- a/routes/notifications/index.tsx
+++ b/routes/notifications/index.tsx
@@ -13,7 +13,7 @@ interface NotificationsState extends SignedInState {
 // deno-lint-ignore no-explicit-any
 export const handler: Handlers<any, NotificationsState> = {
   async GET(_req, ctx) {
-    const notifications = await getNotificationsByUser(ctx.state.user.id);
+    const notifications = await getNotificationsByUser(ctx.state.user.login);
 
     return await ctx.render({ ...ctx.state, notifications });
   },

--- a/routes/submit.tsx
+++ b/routes/submit.tsx
@@ -45,7 +45,7 @@ export const handler: Handlers<State, State> = {
     if (!user) return new Response(null, { status: 400 });
 
     const item: Item = {
-      userId: user.id,
+      userLogin: user.login,
       title,
       url,
       ...newItemProps(),

--- a/routes/user/[login].tsx
+++ b/routes/user/[login].tsx
@@ -8,7 +8,7 @@ import {
   compareScore,
   getAreVotedBySessionId,
   getItemsByUser,
-  getUserByLogin,
+  getUser,
   type Item,
   type User,
 } from "@/utils/db.ts";
@@ -31,12 +31,12 @@ export const handler: Handlers<UserData, State> = {
     const url = new URL(req.url);
     const pageNum = calcPageNum(url);
 
-    const user = await getUserByLogin(ctx.params.login);
+    const user = await getUser(ctx.params.login);
     if (user === null) {
       return ctx.renderNotFound();
     }
 
-    const allItems = await getItemsByUser(user.id);
+    const allItems = await getItemsByUser(user.login);
     const itemsCount = allItems.length;
 
     const items = allItems.sort(compareScore).slice(
@@ -109,7 +109,6 @@ export default function UserPage(props: PageProps<UserData>) {
           <ItemSummary
             item={item}
             isVoted={props.data.areVoted[index]}
-            user={props.data.user}
           />
         ))}
         {props.data.lastPage > 1 && (

--- a/tools/migrate_kv.ts
+++ b/tools/migrate_kv.ts
@@ -1,14 +1,61 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { kv, type Notification } from "@/utils/db.ts";
+import {
+  deleteNotification,
+  Item,
+  kv,
+  type Notification,
+  User,
+} from "@/utils/db.ts";
+
+type OldItem = Omit<Item, "userLogin"> & { userId: string };
+type OldUser = User & { id: string };
+interface OldVote {
+  item: OldItem;
+  user: OldUser;
+}
+
+async function migrateItem(item: OldItem) {
+  const userRes = await kv.get<User>(["users", item.userId]);
+  if (userRes.value === null) {
+    throw new Deno.errors.NotFound(`User not found: ${item.userId}`);
+  }
+
+  const itemsKey = ["items", item.id];
+  const itemsByTimeKey = ["items_by_time", item.createdAt.getTime(), item.id];
+  const itemsByUserKey = ["items_by_user", userRes.value.login, item.id];
+  const oldItemsByUserKey = ["items_by_user", item.userId, item.id];
+
+  const res = await kv.atomic()
+    .set(itemsKey, item)
+    .set(itemsByTimeKey, item)
+    .set(itemsByUserKey, item)
+    .delete(oldItemsByUserKey)
+    .commit();
+
+  if (!res.ok) throw new Error(`Failed to migrate item: ${item}`);
+}
 
 export async function migrateKv() {
-  const iter = kv.list<Notification>({ prefix: ["notifications_by_time"] });
   const promises = [];
-  for await (const entry of iter) {
-    promises.push(kv.delete(entry.key));
+
+  // Items
+  const itemsIter = kv.list<OldItem>({ prefix: ["items"] });
+  for await (const entry of itemsIter) {
+    if (entry.value.userId) {
+      promises.push(migrateItem(entry.value));
+    }
   }
+
+  // Notifications
+  const notificationsIter = kv.list<Notification>({
+    prefix: ["notifications"],
+  });
+  for await (const entry of notificationsIter) {
+    promises.push(deleteNotification(entry.value));
+  }
+
   await Promise.all(promises);
-  console.log("KV migration complete.");
+  console.log("KV migration complete");
 }
 
 if (import.meta.main) {

--- a/tools/migrate_kv.ts
+++ b/tools/migrate_kv.ts
@@ -1,29 +1,91 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import {
-  deleteNotification,
+  assertIsEntry,
   Item,
   kv,
+  newVoteProps,
   type Notification,
   User,
+  Vote,
 } from "@/utils/db.ts";
 
 type OldItem = Omit<Item, "userLogin"> & { userId: string };
 type OldUser = User & { id: string };
-interface OldVote {
-  item: OldItem;
-  user: OldUser;
+
+async function migrateVote(voterUserId: string, oldItem: OldItem) {
+  const [creatorUserRes, voterUserRes] = await kv.getMany<OldUser[]>([
+    ["users", oldItem.userId],
+    ["users", voterUserId],
+  ]);
+  assertIsEntry(creatorUserRes);
+  assertIsEntry(voterUserRes);
+
+  const item: Item = {
+    userLogin: creatorUserRes.value.login,
+    id: oldItem.id,
+    createdAt: oldItem.createdAt,
+    title: oldItem.title,
+    url: oldItem.url,
+    score: oldItem.score,
+  };
+  const vote: Vote = {
+    ...newVoteProps(),
+    item,
+    userLogin: voterUserRes.value.login,
+  };
+
+  const itemKey = ["items", vote.item.id];
+  const itemsByTimeKey = [
+    "items_by_time",
+    vote.item.createdAt.getTime(),
+    vote.item.id,
+  ];
+  const itemsByUserKey = ["items_by_user", vote.item.userLogin, vote.item.id];
+  const [itemRes, itemsByTimeRes, itemsByUserRes] = await kv.getMany([
+    itemKey,
+    itemsByTimeKey,
+    itemsByUserKey,
+  ]);
+  assertIsEntry(itemRes);
+  assertIsEntry(itemsByTimeRes);
+  assertIsEntry(itemsByUserRes);
+
+  const votesKey = ["votes", vote.id];
+  const votesByItemKey = ["votes_by_item", vote.item.id, vote.id];
+  const votesByUserKey = ["votes_by_user", vote.userLogin, vote.id];
+
+  const res = await kv.atomic()
+    .check(itemRes)
+    .check(itemsByTimeRes)
+    .check(itemsByUserRes)
+    .set(itemKey, vote.item)
+    .set(itemsByTimeKey, vote.item)
+    .set(itemsByUserKey, vote.item)
+    .set(votesKey, vote)
+    .set(votesByItemKey, vote)
+    .set(votesByUserKey, vote)
+    .commit();
+
+  if (!res.ok) throw new Error(`Failed to set vote: ${vote}`);
 }
 
-async function migrateItem(item: OldItem) {
-  const userRes = await kv.get<User>(["users", item.userId]);
-  if (userRes.value === null) {
-    throw new Deno.errors.NotFound(`User not found: ${item.userId}`);
-  }
+async function migrateItem(oldItem: OldItem) {
+  const userRes = await kv.get<User>(["users", oldItem.userId]);
+  assertIsEntry(userRes);
+
+  const item: Item = {
+    userLogin: userRes.value.login,
+    id: oldItem.id,
+    createdAt: oldItem.createdAt,
+    title: oldItem.title,
+    url: oldItem.url,
+    score: oldItem.score,
+  };
 
   const itemsKey = ["items", item.id];
   const itemsByTimeKey = ["items_by_time", item.createdAt.getTime(), item.id];
   const itemsByUserKey = ["items_by_user", userRes.value.login, item.id];
-  const oldItemsByUserKey = ["items_by_user", item.userId, item.id];
+  const oldItemsByUserKey = ["items_by_user", oldItem.userId, item.id];
 
   const res = await kv.atomic()
     .set(itemsKey, item)
@@ -36,25 +98,42 @@ async function migrateItem(item: OldItem) {
 }
 
 export async function migrateKv() {
-  const promises = [];
-
-  // Items
-  const itemsIter = kv.list<OldItem>({ prefix: ["items"] });
-  for await (const entry of itemsIter) {
-    if (entry.value.userId) {
-      promises.push(migrateItem(entry.value));
-    }
-  }
+  const promises1 = [];
 
   // Notifications
   const notificationsIter = kv.list<Notification>({
     prefix: ["notifications"],
   });
   for await (const entry of notificationsIter) {
-    promises.push(deleteNotification(entry.value));
+    promises1.push(kv.delete(entry.key));
   }
 
-  await Promise.all(promises);
+  // Notifications by users
+  const notificationsByUsersIter = kv.list<Notification>({
+    prefix: ["notifications_by_user"],
+  });
+  for await (const entry of notificationsByUsersIter) {
+    promises1.push(kv.delete(entry.key));
+  }
+
+  // Votes
+  const votedItemsByUserIter = kv.list<OldItem>({
+    prefix: ["voted_items_by_user"],
+  });
+  for await (const entry of votedItemsByUserIter) {
+    promises1.push(migrateVote(entry.key[1].toString(), entry.value));
+  }
+  await Promise.all(promises1);
+
+  // Items
+  const promises2 = [];
+  const itemsIter = kv.list<OldItem>({ prefix: ["items"] });
+  for await (const entry of itemsIter) {
+    if (entry.value.userId) {
+      promises2.push(migrateItem(entry.value));
+    }
+  }
+  await Promise.all(promises2);
   console.log("KV migration complete");
 }
 

--- a/tools/seed_submissions.ts
+++ b/tools/seed_submissions.ts
@@ -97,8 +97,8 @@ async function main(limit = 20) {
     await Promise.allSettled(batch.map(({ userLogin }) => {
       const user: User = {
         login: userLogin,
-        stripeCustomerId: crypto.randomUUID(), // unique per userId
-        sessionId: crypto.randomUUID(), // unique per userId
+        stripeCustomerId: crypto.randomUUID(), // unique per user
+        sessionId: crypto.randomUUID(), // unique per user
         ...newUserProps(),
       };
       return createUser(user); // ignore errors if dummy user already exists

--- a/tools/seed_submissions.ts
+++ b/tools/seed_submissions.ts
@@ -62,10 +62,10 @@ async function fetchTopStories(limit = 10) {
 }
 
 async function seedSubmissions(stories: Story[]) {
-  const items = stories.map(({ by: userId, title, url, score, time }) => {
+  const items = stories.map(({ by: userLogin, title, url, score, time }) => {
     return {
       ...newItemProps(),
-      userId,
+      userLogin,
       title,
       url,
       score,
@@ -94,10 +94,9 @@ async function main(limit = 20) {
 
   // Create dummy users to ensure each post has a corresponding user
   for (const batch of batchify(items)) {
-    await Promise.allSettled(batch.map(({ userId: id }) => {
+    await Promise.allSettled(batch.map(({ userLogin }) => {
       const user: User = {
-        id, // id must match userId for post
-        login: id,
+        login: userLogin,
         stripeCustomerId: crypto.randomUUID(), // unique per userId
         sessionId: crypto.randomUUID(), // unique per userId
         ...newUserProps(),

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -197,7 +197,7 @@ export function newNotificationProps(): Pick<Item, "id" | "createdAt"> {
  * import { newNotificationProps, createNotification } from "@/utils/db.ts";
  *
  * const notification: Notification = {
- *   userLogin: "example-user-id",
+ *   userLogin: "example-user-login",
  *   type: "example-type",
  *   text: "Hello, world!",
  *   originUrl: "https://hunt.deno.land"
@@ -414,6 +414,7 @@ export async function getVotedItemsByUser(userLogin: string) {
 
 // User
 export interface User {
+  // AKA username
   login: string;
   sessionId: string;
   stripeCustomerId?: string;

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -104,7 +104,7 @@ export async function createItem(item: Item) {
   const itemsKey = ["items", item.id];
   const itemsByTimeKey = ["items_by_time", item.createdAt.getTime(), item.id];
   const itemsByUserKey = ["items_by_user", item.userLogin, item.id];
-  const itemsCountKey = ["items_count", formatDate(new Date())];
+  const itemsCountKey = ["items_count", formatDate(item.createdAt)];
 
   const res = await kv.atomic()
     .check({ key: itemsKey, versionstamp: null })

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -21,11 +21,9 @@ import {
   getItemsByUser,
   getItemsSince,
   getManyMetrics,
-  getManyUsers,
   getNotification,
   getNotificationsByUser,
   getUser,
-  getUserByLogin,
   getUserBySession,
   getUserByStripeCustomer,
   getVotedItemsByUser,
@@ -48,29 +46,26 @@ import {
 } from "std/testing/asserts.ts";
 import { DAY } from "std/datetime/constants.ts";
 
-function genNewComment(comment?: Partial<Comment>): Comment {
+function genNewComment(): Comment {
   return {
     itemId: crypto.randomUUID(),
     userLogin: crypto.randomUUID(),
     text: crypto.randomUUID(),
     ...newCommentProps(),
-    ...comment,
   };
 }
 
-function genNewItem(item?: Partial<Item>): Item {
+function genNewItem(): Item {
   return {
-    userId: crypto.randomUUID(),
+    userLogin: crypto.randomUUID(),
     title: crypto.randomUUID(),
     url: `http://${crypto.randomUUID()}.com`,
     ...newItemProps(),
-    ...item,
   };
 }
 
 function genNewUser(): User {
   return {
-    id: crypto.randomUUID(),
     login: crypto.randomUUID(),
     sessionId: crypto.randomUUID(),
     stripeCustomerId: crypto.randomUUID(),
@@ -113,22 +108,23 @@ Deno.test("[db] (get/create/delete)Item()", async () => {
 });
 
 Deno.test("[db] getItemsByUser()", async () => {
-  const userId = crypto.randomUUID();
-  const item1 = genNewItem({ userId });
-  const item2 = genNewItem({ userId });
+  const userLogin = crypto.randomUUID();
+  const item1 = { ...genNewItem(), userLogin };
+  const item2 = { ...genNewItem(), userLogin };
 
-  assertEquals(await getItemsByUser(userId), []);
+  assertEquals(await getItemsByUser(userLogin), []);
 
   await createItem(item1);
   await createItem(item2);
-  assertArrayIncludes(await getItemsByUser(userId), [item1, item2]);
+  assertArrayIncludes(await getItemsByUser(userLogin), [item1, item2]);
 });
 
 Deno.test("[db] getItemsSince()", async () => {
   const item1 = genNewItem();
-  const item2 = genNewItem({
+  const item2 = {
+    ...genNewItem(),
     createdAt: new Date(Date.now() - (2 * DAY)),
-  });
+  };
 
   await createItem(item1);
   await createItem(item2);
@@ -140,30 +136,26 @@ Deno.test("[db] getItemsSince()", async () => {
 Deno.test("[db] user", async () => {
   const user = genNewUser();
 
-  assertEquals(await getUser(user.id), null);
-  assertEquals(await getUserByLogin(user.login), null);
+  assertEquals(await getUser(user.login), null);
   assertEquals(await getUserBySession(user.sessionId), null);
   assertEquals(await getUserByStripeCustomer(user.stripeCustomerId!), null);
 
   await createUser(user);
   await assertRejects(async () => await createUser(user));
   assertEquals(await getManyMetrics("users_count", [new Date()]), [1n]);
-  assertEquals(await getUser(user.id), user);
-  assertEquals(await getUserByLogin(user.login), user);
+  assertEquals(await getUser(user.login), user);
   assertEquals(await getUserBySession(user.sessionId), user);
   assertEquals(await getUserByStripeCustomer(user.stripeCustomerId!), user);
 
   const user1 = genNewUser();
   await createUser(user1);
-  assertArrayIncludes(await getManyUsers([user.id, user1.id]), [user, user1]);
 
   await deleteUserBySession(user.sessionId);
   assertEquals(await getUserBySession(user.sessionId), null);
 
   const newUser: User = { ...user, sessionId: crypto.randomUUID() };
   await updateUser(newUser);
-  assertEquals(await getUser(newUser.id), newUser);
-  assertEquals(await getUserByLogin(newUser.login), newUser);
+  assertEquals(await getUser(newUser.login), newUser);
   assertEquals(await getUserBySession(newUser.sessionId), newUser);
   assertEquals(
     await getUserByStripeCustomer(newUser.stripeCustomerId!),
@@ -185,12 +177,8 @@ Deno.test("[db] newCommentProps()", () => {
 
 Deno.test("[db] (create/delete)Comment() + getCommentsByItem()", async () => {
   const itemId = crypto.randomUUID();
-  const comment1 = genNewComment({
-    itemId,
-  });
-  const comment2 = genNewComment({
-    itemId,
-  });
+  const comment1 = { ...genNewComment(), itemId };
+  const comment2 = { ...genNewComment(), itemId };
 
   assertEquals(await getCommentsByItem(itemId), []);
 
@@ -208,15 +196,15 @@ Deno.test("[db] votes", async () => {
   const user = genNewUser();
   const item = genNewItem();
 
-  assertEquals(await getVotedItemsByUser(user.id), []);
+  assertEquals(await getVotedItemsByUser(user.login), []);
 
   const dates = [new Date()];
   assertEquals(await getManyMetrics("votes_count", dates), [0n]);
   await createVote({ item, user });
   assertEquals(await getManyMetrics("votes_count", dates), [1n]);
-  assertEquals(await getVotedItemsByUser(user.id), [item]);
+  assertEquals(await getVotedItemsByUser(user.login), [item]);
   await deleteVote({ item, user });
-  assertEquals(await getVotedItemsByUser(user.id), []);
+  assertEquals(await getVotedItemsByUser(user.login), []);
   await createVote({ item, user });
   assertRejects(async () => await createVote({ item, user }));
   await deleteVote({ item, user });
@@ -249,7 +237,7 @@ function genNewNotification(
   notification?: Partial<Notification>,
 ): Notification {
   return {
-    userId: crypto.randomUUID(),
+    userLogin: crypto.randomUUID(),
     type: crypto.randomUUID(),
     text: crypto.randomUUID(),
     originUrl: crypto.randomUUID(),
@@ -278,39 +266,39 @@ Deno.test("[db] (get/create/delete)Notification()", async () => {
 });
 
 Deno.test("[db] getNotificationsByUser()", async () => {
-  const userId = crypto.randomUUID();
-  const notification1 = genNewNotification({ userId });
-  const notification2 = genNewNotification({ userId });
+  const userLogin = crypto.randomUUID();
+  const notification1 = genNewNotification({ userLogin });
+  const notification2 = genNewNotification({ userLogin });
 
-  assertEquals(await getNotificationsByUser(userId), []);
-  assertEquals(await ifUserHasNotifications(userId), false);
+  assertEquals(await getNotificationsByUser(userLogin), []);
+  assertEquals(await ifUserHasNotifications(userLogin), false);
 
   await createNotification(notification1);
   await createNotification(notification2);
-  assertArrayIncludes(await getNotificationsByUser(userId), [
+  assertArrayIncludes(await getNotificationsByUser(userLogin), [
     notification1,
     notification2,
   ]);
-  assertEquals(await ifUserHasNotifications(userId), true);
+  assertEquals(await ifUserHasNotifications(userLogin), true);
 });
 
 Deno.test("[db] compareScore()", () => {
   const item1: Item = {
-    userId: crypto.randomUUID(),
+    userLogin: crypto.randomUUID(),
     title: crypto.randomUUID(),
     url: `http://${crypto.randomUUID()}.com`,
     ...newItemProps(),
     score: 1,
   };
   const item2: Item = {
-    userId: crypto.randomUUID(),
+    userLogin: crypto.randomUUID(),
     title: crypto.randomUUID(),
     url: `http://${crypto.randomUUID()}.com`,
     ...newItemProps(),
     score: 2,
   };
   const item3: Item = {
-    userId: crypto.randomUUID(),
+    userLogin: crypto.randomUUID(),
     title: crypto.randomUUID(),
     url: `http://${crypto.randomUUID()}.com`,
     ...newItemProps(),
@@ -325,7 +313,7 @@ Deno.test("[db] compareScore()", () => {
 
 Deno.test("[db] getAreVotedBySessionId()", async () => {
   const item: Item = {
-    userId: crypto.randomUUID(),
+    userLogin: crypto.randomUUID(),
     title: crypto.randomUUID(),
     url: `http://${crypto.randomUUID()}.com`,
     ...newItemProps(),


### PR DESCRIPTION
Vote logic was challenging to deal with, hence the rework. The most involved part of this PR is the migration script. In summary:
* All notifications will be deleted, which, IMO, is ok.
* User entries are untouched.
* Items and votes entries are migrated according to their new respective interfaces.

Reviews, please pay close attention to the migration script. It aims to preserve item, vote and user data. This script has worked multiple times on my local machine, but I still want it checked carefully. To test:
1. On the main branch, run `deno task db:reset` and then `deno task db:seed`.
2. Run `deno task start`, sign in, vote and comment on random items, noting the changes.
3. Switch to this branch and run `deno run -A --unstable tools/migrate_kv.ts`.
4. Run `deno task start` and ensure all data is preserved.

Please review, if willing and able, @brunocorrea23 and @mbhrznr.

Closes #400