### PR TITLE
fix: add an empty state to the project list

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -192,3 +192,23 @@ export function Cross(props: JSX.SVGAttributes<SVGSVGElement>) {
     </svg>
   );
 }
+
+export function Info(props: JSX.SVGAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="w-6 h-6"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+      />
+    </svg>
+  );
+}

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -92,8 +92,8 @@ export default function HomePage(props: PageProps<HomePageData>) {
         {props.data.items.length === 0 && (
           <>
             <div class="flex flex-col justify-center items-center gap-2">
-              <div class="flex justify-center gap-2 pt-16">
-                <Info class="w-6 h-6" />
+              <div class="flex flex-col items-center gap-2 pt-16">
+                <Info class="w-10 h-10 text-gray-400 dark:text-gray-600" />
                 <p class="text-center font-medium">No items found</p>
               </div>
 

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -94,7 +94,7 @@ export default function HomePage(props: PageProps<HomePageData>) {
             <div class="flex flex-col justify-center items-center gap-2">
               <div class="flex justify-center gap-2 pt-16">
                 <Info class="w-6 h-6" />
-                <p class="text-center font-medium">No items found.</p>
+                <p class="text-center font-medium">No items found</p>
               </div>
 
               <a

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -17,6 +17,7 @@ import { DAY, WEEK } from "std/datetime/constants.ts";
 import { getToggledStyles } from "@/utils/display.ts";
 import { ACTIVE_LINK_STYLES, LINK_STYLES } from "@/utils/constants.ts";
 import Head from "@/components/Head.tsx";
+import { Info } from "@/components/Icons.tsx";
 
 interface HomePageData extends State {
   itemsUsers: User[];
@@ -104,6 +105,24 @@ export default function HomePage(props: PageProps<HomePageData>) {
       <Head href={props.url.href} />
       <main class="flex-1 p-4">
         <TimeSelector url={props.url} />
+        {props.data.items.length === 0 && (
+          <>
+            <div class="flex flex-col justify-center items-center gap-2">
+              <div class="flex justify-center gap-2 pt-16">
+                <Info class="w-6 h-6" />
+                <p class="text-center font-medium">No items found.</p>
+              </div>
+
+              <a
+                href="/submit"
+                class="inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-primary hover:underline"
+              >
+                Submit your project
+              </a>
+            </div>
+          </>
+        )}
+
         {props.data.items.map((item, index) => (
           <ItemSummary
             item={item}


### PR DESCRIPTION
This PR adds empty states to the project list, it guides new users after a fresh install.

<img width="862" alt="image" src="https://github.com/denoland/saaskit/assets/3132889/1dd11fbf-7347-4c21-8756-f91c4c60ab59">
<img width="862" alt="image" src="https://github.com/denoland/saaskit/assets/3132889/763b7e0d-8d8b-4bdb-8115-8197a677102b">
