### PR TITLE
doc: add a link to auth setup guide

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -212,3 +212,23 @@ export function Info(props: JSX.SVGAttributes<SVGSVGElement>) {
     </svg>
   );
 }
+
+export function ArrowRight(props: JSX.SVGAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="w-6 h-6"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+      />
+    </svg>
+  );
+}

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -25,7 +25,7 @@ interface HomePageData extends State {
   areVoted: boolean[];
 }
 
-const needsSetup = Deno.env.get("GITHUB_CLIENT_ID") === undefined ||
+const NEEDS_SETUP = Deno.env.get("GITHUB_CLIENT_ID") === undefined ||
   Deno.env.get("GITHUB_CLIENT_SECRET") === undefined;
 
 function calcTimeAgoFilter(url: URL) {
@@ -131,8 +131,7 @@ export default function HomePage(props: PageProps<HomePageData>) {
     <>
       <Head href={props.url.href} />
       <main class="flex-1 p-4">
-        {needsSetup && <SetupInstruction />}
-
+        {NEEDS_SETUP && <SetupInstruction />}
         <TimeSelector url={props.url} />
         {props.data.items.length === 0 && (
           <>

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -23,8 +23,10 @@ interface HomePageData extends State {
   items: Item[];
   lastPage: number;
   areVoted: boolean[];
-  needsSetup: boolean;
 }
+
+const needsSetup = Deno.env.get("GITHUB_CLIENT_ID") === undefined ||
+  Deno.env.get("GITHUB_CLIENT_SECRET") === undefined;
 
 function calcTimeAgoFilter(url: URL) {
   return url.searchParams.get("time-ago");
@@ -55,8 +57,6 @@ export const handler: Handlers<HomePageData, State> = {
       ctx.state.sessionId,
     );
     const lastPage = calcLastPage(allItems.length, PAGE_LENGTH);
-    const needsSetup = Deno.env.get("GITHUB_CLIENT_ID") === undefined ||
-      Deno.env.get("GITHUB_CLIENT_SECRET") === undefined;
 
     return ctx.render({
       ...ctx.state,
@@ -64,7 +64,6 @@ export const handler: Handlers<HomePageData, State> = {
       itemsUsers,
       areVoted,
       lastPage,
-      needsSetup,
     });
   },
 };
@@ -132,7 +131,7 @@ export default function HomePage(props: PageProps<HomePageData>) {
     <>
       <Head href={props.url.href} />
       <main class="flex-1 p-4">
-        {props.data.needsSetup && <SetupInstruction />}
+        {needsSetup && <SetupInstruction />}
 
         <TimeSelector url={props.url} />
         {props.data.items.length === 0 && (

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/utils/db.ts";
 import { DAY, WEEK } from "std/datetime/constants.ts";
 import Head from "@/components/Head.tsx";
-import { Info } from "@/components/Icons.tsx";
+import { ArrowRight, Info } from "@/components/Icons.tsx";
 import { TabItem } from "@/components/TabsBar.tsx";
 
 interface HomePageData extends State {
@@ -23,6 +23,7 @@ interface HomePageData extends State {
   items: Item[];
   lastPage: number;
   areVoted: boolean[];
+  needsSetup: boolean;
 }
 
 function calcTimeAgoFilter(url: URL) {
@@ -54,8 +55,17 @@ export const handler: Handlers<HomePageData, State> = {
       ctx.state.sessionId,
     );
     const lastPage = calcLastPage(allItems.length, PAGE_LENGTH);
+    const needsSetup = Deno.env.get("GITHUB_CLIENT_ID") === undefined ||
+      Deno.env.get("GITHUB_CLIENT_SECRET") === undefined;
 
-    return ctx.render({ ...ctx.state, items, itemsUsers, areVoted, lastPage });
+    return ctx.render({
+      ...ctx.state,
+      items,
+      itemsUsers,
+      areVoted,
+      lastPage,
+      needsSetup,
+    });
   },
 };
 
@@ -83,11 +93,47 @@ function TimeSelector(props: { url: URL }) {
   );
 }
 
+function SetupInstrucion() {
+  return (
+    <div class="bg-green-50 dark:(bg-gray-900 border border-green-800) rounded-xl max-w-screen-sm mx-auto my-8 px-6 py-5 space-y-3">
+      <h1 class="text-2xl font-medium">Welcome to SaaSKit!</h1>
+
+      <p class="text-gray-600 dark:text-gray-400">
+        To enable user login, you need to configure the GitHub OAuth application
+        and set environment variables.
+      </p>
+
+      <p>
+        <a
+          href="https://github.com/denoland/saaskit#auth-oauth"
+          class="inline-flex gap-2 text-green-600 dark:text-green-400 hover:underline cursor-pointer"
+        >
+          See the guide
+          <ArrowRight class="w-4 h-4 inline-block" />
+        </a>
+      </p>
+
+      <p class="text-gray-600 dark:text-gray-400">
+        After setting up{" "}
+        <span class="bg-green-100 dark:bg-gray-800 p-1 rounded">
+          GITHUB_CLIENT_ID
+        </span>{" "}
+        and{" "}
+        <span class="bg-green-100 dark:bg-gray-800 p-1 rounded">
+          GITHUB_CLIENT_SECRET
+        </span>, this message will disappear.
+      </p>
+    </div>
+  );
+}
+
 export default function HomePage(props: PageProps<HomePageData>) {
   return (
     <>
       <Head href={props.url.href} />
       <main class="flex-1 p-4">
+        {props.data.needsSetup && <SetupInstrucion />}
+
         <TimeSelector url={props.url} />
         {props.data.items.length === 0 && (
           <>

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -93,7 +93,7 @@ function TimeSelector(props: { url: URL }) {
   );
 }
 
-function SetupInstrucion() {
+function SetupInstruction() {
   return (
     <div class="bg-green-50 dark:(bg-gray-900 border border-green-800) rounded-xl max-w-screen-sm mx-auto my-8 px-6 py-5 space-y-3">
       <h1 class="text-2xl font-medium">Welcome to SaaSKit!</h1>
@@ -132,7 +132,7 @@ export default function HomePage(props: PageProps<HomePageData>) {
     <>
       <Head href={props.url.href} />
       <main class="flex-1 p-4">
-        {props.data.needsSetup && <SetupInstrucion />}
+        {props.data.needsSetup && <SetupInstruction />}
 
         <TimeSelector url={props.url} />
         {props.data.items.length === 0 && (


### PR DESCRIPTION
Just an idea, how about issuing an instruction when `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are not set? I think It reduces the feeling of emptyness after initial setup, and it will prevent users from getting lost in both the local environment and the Deno Deploy environment.

If these environment variables are not required, I think this PR is not appropriate and should be closed.

Feel free to rewrite the text if you like this idea.

<img width="967" alt="image" src="https://github.com/denoland/saaskit/assets/3132889/a9f54103-a677-4f54-aab2-477d36a65179">

<img width="963" alt="image" src="https://github.com/denoland/saaskit/assets/3132889/7bdaef5f-666c-4813-9114-e17c83b7f1f6">
