### PR TITLE
feat: admin pannel

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -18,7 +18,7 @@
   },
   "imports": {
     "@/": "./",
-    "$fresh/": "https://deno.land/x/fresh@1.3.0/",
+    "$fresh/": "https://raw.githubusercontent.com/deer/fresh/feat_plugin_islands/",
     "$gfm": "https://deno.land/x/gfm@0.2.4/mod.ts",
     "preact": "https://esm.sh/preact@10.15.1",
     "preact/": "https://esm.sh/preact@10.15.1/",
@@ -32,6 +32,8 @@
     "feed": "https://esm.sh/feed@4.2.2",
     "kv_oauth": "https://deno.land/x/deno_kv_oauth@v0.2.5/mod.ts",
     "@twind/core": "https://esm.sh/@twind/core@1.1.3",
+    "pentagon/": "https://deno.land/x/pentagon@v0.1.2/",
+    "z": "https://deno.land/x/zod@v3.21.4/mod.ts",
     "fresh_charts/": "https://deno.land/x/fresh_charts@0.3.1/"
   },
   "exclude": [

--- a/main.ts
+++ b/main.ts
@@ -6,11 +6,16 @@
 /// <reference lib="deno.ns" />
 /// <reference lib="deno.unstable" />
 
+import * as path from "std/path/mod.ts";
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";
 
 import twindPlugin from "$fresh/plugins/twindv1.ts";
 import twindConfig from "./twind.config.ts";
+
+import {
+  kvAdminPlugin,
+} from "https://raw.githubusercontent.com/deer/fresh_kv_admin/main/mod.ts";
 
 /**
  * @todo Remove at v1. This is a quick way to reset Deno KV, as database changes are likely to occur and require reset.
@@ -29,4 +34,11 @@ if (Deno.env.get("MIGRATE_DENO_KEY") === "1") {
   await migrateKv();
 }
 
-await start(manifest, { plugins: [twindPlugin(twindConfig)] });
+await start(manifest, {
+  plugins: [
+    twindPlugin(twindConfig),
+    await kvAdminPlugin({
+      modelPath: path.join(path.dirname(import.meta.url), "utils/types.ts"),
+    }),
+  ],
+});

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,0 +1,28 @@
+// import { Item } from "./db.ts";
+import { TableDefinition } from "pentagon/src/types.ts";
+import { z } from "z";
+
+export interface Item {
+  userId: string;
+  title: string;
+  url: string;
+  // The below properties can be automatically generated upon item creation
+  id: string;
+  createdAt: Date;
+  score: number;
+}
+
+const item = z.object({
+  id: z.string().uuid().describe("primary"),
+  createdAt: z.coerce.date(),
+  score: z.coerce.number(),
+  url: z.string(),
+  title: z.string(),
+  userId: z.string().uuid(),
+});
+
+export const schema: Record<string, TableDefinition> = {
+  items: {
+    schema: item,
+  },
+};


### PR DESCRIPTION
closes https://github.com/denoland/saaskit/issues/73

Hey @iuioiua, this is incredibly rough right now, but you encouraged me to open something so we can iterate on the idea.

With these changes, then I can go to the following routes:
* http://localhost:8000/models
* http://localhost:8000/items
* http://localhost:8000/items/new

There are currently two major issues:
* The styling is horrible. I need to get the plugin to accept styles that get applied to the routes it creates.
* The plugin only works with pentagon right now. So most of the functionality doesn't work! I'm at least glad that I can show the items, otherwise I wouldn't even open this. Ideally the user of the plugin could map their own CRUD functions to types, instead of forcing the plugin user to create (possibly unnecessary/unwanted) pentagon models.

I will get to these enhancements at some point and then post an update here. Hopefully that will get rid of the pentagon and zod imports.

After those are dealt with, I can turn to a better layout (likely some sort of table) and then security / permissions.