### PR TITLE
refactor: cursor-based pagination for comments

### DIFF
--- a/components/PaginationLink.tsx
+++ b/components/PaginationLink.tsx
@@ -1,0 +1,17 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+export default function Pagination(
+  props: { url: URL; cursor?: string; class?: string },
+) {
+  const url = new URL(props.url);
+  let text: string;
+  if (props.cursor) {
+    url.searchParams.set("cursor", props.cursor);
+    text = "Next ›";
+  } else {
+    url.searchParams.delete("cursor");
+    text = "Back to start ↻";
+  }
+  return props.url.href === url.href
+    ? null
+    : <a href={url.href} class={props.class}>{text}</a>;
+}

--- a/components/PaginationLink.tsx
+++ b/components/PaginationLink.tsx
@@ -1,10 +1,15 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export default function Pagination(
-  props: { url: URL; cursor?: string },
+  props: {
+    url: URL;
+    cursor?: string;
+    /** @todo https://github.com/denoland/deno/issues/20173 */
+    done?: boolean;
+  },
 ) {
   const url = new URL(props.url);
   let text: string;
-  if (props.cursor) {
+  if (props.cursor && !props.done) {
     url.searchParams.set("cursor", props.cursor);
     text = "Next ›";
   } else {

--- a/components/PaginationLink.tsx
+++ b/components/PaginationLink.tsx
@@ -3,8 +3,7 @@ export default function Pagination(
   props: {
     url: URL;
     cursor?: string;
-    /** @todo https://github.com/denoland/deno/issues/20173 */
-    done?: boolean;
+    done: boolean;
   },
 ) {
   const url = new URL(props.url);

--- a/components/PaginationLink.tsx
+++ b/components/PaginationLink.tsx
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export default function Pagination(
-  props: { url: URL; cursor?: string; class?: string },
+  props: { url: URL; cursor?: string },
 ) {
   const url = new URL(props.url);
   let text: string;
@@ -11,7 +11,12 @@ export default function Pagination(
     url.searchParams.delete("cursor");
     text = "Back to start ↻";
   }
-  return props.url.href === url.href
-    ? null
-    : <a href={url.href} class={props.class}>{text}</a>;
+  return props.url.href === url.href ? null : (
+    <a
+      href={url.href}
+      class="px-4 py-2 transition duration-300 rounded-lg hover:(bg-gray-100 dark:bg-gray-800)"
+    >
+      {text}
+    </a>
+  );
 }

--- a/routes/items/[id].tsx
+++ b/routes/items/[id].tsx
@@ -117,11 +117,12 @@ export default async function ItemsItemPage(
             />
           ))}
         </div>
-        <PaginationLink
-          url={ctx.url}
-          cursor={iter.cursor}
-          class="text-centre my-8"
-        />
+        <div class="text-center w-full">
+          <PaginationLink
+            url={ctx.url}
+            cursor={iter.cursor}
+          />
+        </div>
       </main>
     </>
   );

--- a/routes/items/[id].tsx
+++ b/routes/items/[id].tsx
@@ -96,6 +96,12 @@ export default async function ItemsItemPage(
   const iter = listCommentsByItem(itemId, { cursor });
   const comments = await valuesFromIter(iter);
 
+  console.log(iter.cursor);
+
+  /** @todo https://github.com/denoland/deno/issues/20173 */
+  const nextPageIter = listCommentsByItem(itemId, { cursor: iter.cursor });
+  const { done } = await nextPageIter.next();
+
   const [isVoted] = await getAreVotedBySessionId(
     [item],
     ctx.state.sessionId,
@@ -121,6 +127,7 @@ export default async function ItemsItemPage(
           <PaginationLink
             url={ctx.url}
             cursor={iter.cursor}
+            done={done}
           />
         </div>
       </main>

--- a/routes/items/[id].tsx
+++ b/routes/items/[id].tsx
@@ -96,8 +96,6 @@ export default async function ItemsItemPage(
   const iter = listCommentsByItem(itemId, { cursor });
   const comments = await valuesFromIter(iter);
 
-  console.log(iter.cursor);
-
   /** @todo https://github.com/denoland/deno/issues/20173 */
   const nextPageIter = listCommentsByItem(itemId, { cursor: iter.cursor });
   const { done } = await nextPageIter.next();

--- a/tools/migrate_kv.ts
+++ b/tools/migrate_kv.ts
@@ -1,21 +1,13 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { kv, updateUser, User } from "@/utils/db.ts";
-
-type MaybeOldUser = User & {
-  id?: string;
-  avatarUrl?: string;
-};
+import { type Comment, createComment, kv } from "@/utils/db.ts";
 
 export async function migrateKv() {
   const promises = [];
-  const iter = kv.list<MaybeOldUser>({ prefix: ["users"] });
+  const iter = kv.list<Comment>({ prefix: ["comments_by_item"] });
   for await (const entry of iter) {
-    const user = entry.value;
-    if (user.id) {
-      promises.push(kv.delete(["users", user.id]));
-      delete user.id;
-      delete user.avatarUrl;
-      promises.push(updateUser(user));
+    if (entry.key.length === 3) {
+      promises.push(kv.delete(entry.key));
+      promises.push(createComment(entry.value));
     }
   }
   await Promise.all(promises);

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -329,7 +329,6 @@ export function listCommentsByItem(
   options?: Deno.KvListOptions,
 ) {
   return kv.list<Comment>({ prefix: ["comments_by_item", itemId] }, {
-    limit: 10,
     reverse: true,
     ...options,
   });

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -15,7 +15,6 @@ import {
   formatDate,
   getAllItems,
   getAreVotedBySessionId,
-  getCommentsByItem,
   getDatesSince,
   getItem,
   getItemsByUser,
@@ -30,6 +29,7 @@ import {
   ifUserHasNotifications,
   incrVisitsCountByDay,
   type Item,
+  listCommentsByItem,
   newCommentProps,
   newItemProps,
   newNotificationProps,
@@ -38,6 +38,7 @@ import {
   Notification,
   updateUser,
   type User,
+  valuesFromIter,
 } from "./db.ts";
 import {
   assert,
@@ -191,16 +192,19 @@ Deno.test("[db] (create/delete)Comment() + getCommentsByItem()", async () => {
   const comment1 = { ...genNewComment(), itemId };
   const comment2 = { ...genNewComment(), itemId };
 
-  assertEquals(await getCommentsByItem(itemId), []);
+  assertEquals(await valuesFromIter(listCommentsByItem(itemId)), []);
 
   await createComment(comment1);
   await createComment(comment2);
   await assertRejects(async () => await createComment(comment2));
-  assertArrayIncludes(await getCommentsByItem(itemId), [comment1, comment2]);
+  assertArrayIncludes(await valuesFromIter(listCommentsByItem(itemId)), [
+    comment1,
+    comment2,
+  ]);
 
   await deleteComment(comment1);
   await deleteComment(comment2);
-  assertEquals(await getCommentsByItem(itemId), []);
+  assertEquals(await valuesFromIter(listCommentsByItem(itemId)), []);
 });
 
 Deno.test("[db] votes", async () => {

--- a/utils/pagination.ts
+++ b/utils/pagination.ts
@@ -10,3 +10,27 @@ export function calcPageNum(url: URL) {
 export function calcLastPage(total = 0, pageLength = PAGE_LENGTH): number {
   return Math.ceil(total / pageLength);
 }
+
+export function getCursor(url: URL) {
+  return url.searchParams.get("cursor") ?? undefined;
+}
+
+export async function getPagination<T>(
+  iter: Deno.KvListIterator<T>,
+  limit: number,
+) {
+  const values: T[] = [];
+  let cursor = "";
+  let done = true;
+  for await (const entry of iter) {
+    if (values.length <= limit - 1) {
+      values.push(entry.value);
+      cursor = iter.cursor;
+    } else {
+      done = false;
+      break;
+    }
+  }
+
+  return { values, cursor, done };
+}


### PR DESCRIPTION
This change introduces a pagination style that's more natural for Deno KV. The kind of pagination is unconventional but remarkably simple, IMO. Once merged, we'll make this the default pagination method for the site.

Note: the last page is empty. This occurs on the last iteration of the async iterator when the [`limit` option](https://deno.land/api@v1.36.1?s=Deno.KvListOptions&unstable=#prop_limit) is divisible by the total number of results of the async iterator. E.g. `limit = 2` and total results = 10, as in this video. Is this a bug?

https://github.com/denoland/saaskit/assets/29347852/d3e144e2-25db-4e5a-82ba-fa4073677850

Towards #414