### PR TITLE
feat: cursor-based pagination for comments using infinite scroll

### DIFF
--- a/components/CommentSummary.tsx
+++ b/components/CommentSummary.tsx
@@ -1,3 +1,4 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import UserPostedAt from "./UserPostedAt.tsx";
 import { Comment } from "@/utils/db.ts";
 

--- a/components/CommentSummary.tsx
+++ b/components/CommentSummary.tsx
@@ -1,0 +1,11 @@
+import UserPostedAt from "./UserPostedAt.tsx";
+import { Comment } from "@/utils/db.ts";
+
+export default function CommentSummary(props: Comment) {
+  return (
+    <div class="py-4">
+      <UserPostedAt {...props} />
+      <p>{props.text}</p>
+    </div>
+  );
+}

--- a/components/PaginationLink.tsx
+++ b/components/PaginationLink.tsx
@@ -1,0 +1,17 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+export default function Pagination(
+  props: { url: URL; cursor?: string; class?: string },
+) {
+  const url = new URL(props.url);
+  let text: string;
+  if (props.cursor) {
+    url.searchParams.set("cursor", props.cursor);
+    text = "Next ›";
+  } else {
+    url.searchParams.delete("cursor");
+    text = "Back to start ↻";
+  }
+  return props.url.href === url.href
+    ? null
+    : <a href={url.href} class={props.class}>{text}</a>;
+}

--- a/components/PaginationLink.tsx
+++ b/components/PaginationLink.tsx
@@ -1,10 +1,15 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export default function Pagination(
-  props: { url: URL; cursor?: string },
+  props: {
+    url: URL;
+    cursor?: string;
+    /** @todo https://github.com/denoland/deno/issues/20173 */
+    done?: boolean;
+  },
 ) {
   const url = new URL(props.url);
   let text: string;
-  if (props.cursor) {
+  if (props.cursor && !props.done) {
     url.searchParams.set("cursor", props.cursor);
     text = "Next ›";
   } else {

--- a/components/PaginationLink.tsx
+++ b/components/PaginationLink.tsx
@@ -3,8 +3,7 @@ export default function Pagination(
   props: {
     url: URL;
     cursor?: string;
-    /** @todo https://github.com/denoland/deno/issues/20173 */
-    done?: boolean;
+    done: boolean;
   },
 ) {
   const url = new URL(props.url);

--- a/components/PaginationLink.tsx
+++ b/components/PaginationLink.tsx
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export default function Pagination(
-  props: { url: URL; cursor?: string; class?: string },
+  props: { url: URL; cursor?: string },
 ) {
   const url = new URL(props.url);
   let text: string;
@@ -11,7 +11,12 @@ export default function Pagination(
     url.searchParams.delete("cursor");
     text = "Back to start ↻";
   }
-  return props.url.href === url.href
-    ? null
-    : <a href={url.href} class={props.class}>{text}</a>;
+  return props.url.href === url.href ? null : (
+    <a
+      href={url.href}
+      class="px-4 py-2 transition duration-300 rounded-lg hover:(bg-gray-100 dark:bg-gray-800)"
+    >
+      {text}
+    </a>
+  );
 }

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -10,30 +10,32 @@ import * as $4 from "./routes/account/_middleware.ts";
 import * as $5 from "./routes/account/index.tsx";
 import * as $6 from "./routes/account/manage.ts";
 import * as $7 from "./routes/account/upgrade.ts";
-import * as $8 from "./routes/api/stripe-webhooks.ts";
-import * as $9 from "./routes/api/vote.ts";
-import * as $10 from "./routes/blog/[slug].tsx";
-import * as $11 from "./routes/blog/index.tsx";
-import * as $12 from "./routes/callback.ts";
-import * as $13 from "./routes/dashboard/_middleware.ts";
-import * as $14 from "./routes/dashboard/index.tsx";
-import * as $15 from "./routes/dashboard/stats.tsx";
-import * as $16 from "./routes/dashboard/users.tsx";
-import * as $17 from "./routes/feed.ts";
-import * as $18 from "./routes/index.tsx";
-import * as $19 from "./routes/items/[id].tsx";
-import * as $20 from "./routes/notifications/[id].ts";
-import * as $21 from "./routes/notifications/_middleware.ts";
-import * as $22 from "./routes/notifications/index.tsx";
-import * as $23 from "./routes/pricing.tsx";
-import * as $24 from "./routes/signin.ts";
-import * as $25 from "./routes/signout.ts";
-import * as $26 from "./routes/submit/_middleware.tsx";
-import * as $27 from "./routes/submit/index.tsx";
-import * as $28 from "./routes/users/[login].tsx";
+import * as $8 from "./routes/api/items/[id]/comments.ts";
+import * as $9 from "./routes/api/stripe-webhooks.ts";
+import * as $10 from "./routes/api/vote.ts";
+import * as $11 from "./routes/blog/[slug].tsx";
+import * as $12 from "./routes/blog/index.tsx";
+import * as $13 from "./routes/callback.ts";
+import * as $14 from "./routes/dashboard/_middleware.ts";
+import * as $15 from "./routes/dashboard/index.tsx";
+import * as $16 from "./routes/dashboard/stats.tsx";
+import * as $17 from "./routes/dashboard/users.tsx";
+import * as $18 from "./routes/feed.ts";
+import * as $19 from "./routes/index.tsx";
+import * as $20 from "./routes/items/[id].tsx";
+import * as $21 from "./routes/notifications/[id].ts";
+import * as $22 from "./routes/notifications/_middleware.ts";
+import * as $23 from "./routes/notifications/index.tsx";
+import * as $24 from "./routes/pricing.tsx";
+import * as $25 from "./routes/signin.ts";
+import * as $26 from "./routes/signout.ts";
+import * as $27 from "./routes/submit/_middleware.tsx";
+import * as $28 from "./routes/submit/index.tsx";
+import * as $29 from "./routes/users/[login].tsx";
 import * as $$0 from "./islands/Chart.tsx";
-import * as $$1 from "./islands/PageInput.tsx";
-import * as $$2 from "./islands/VoteButton.tsx";
+import * as $$1 from "./islands/CommentsList.tsx";
+import * as $$2 from "./islands/PageInput.tsx";
+import * as $$3 from "./islands/VoteButton.tsx";
 
 const manifest = {
   routes: {
@@ -45,32 +47,34 @@ const manifest = {
     "./routes/account/index.tsx": $5,
     "./routes/account/manage.ts": $6,
     "./routes/account/upgrade.ts": $7,
-    "./routes/api/stripe-webhooks.ts": $8,
-    "./routes/api/vote.ts": $9,
-    "./routes/blog/[slug].tsx": $10,
-    "./routes/blog/index.tsx": $11,
-    "./routes/callback.ts": $12,
-    "./routes/dashboard/_middleware.ts": $13,
-    "./routes/dashboard/index.tsx": $14,
-    "./routes/dashboard/stats.tsx": $15,
-    "./routes/dashboard/users.tsx": $16,
-    "./routes/feed.ts": $17,
-    "./routes/index.tsx": $18,
-    "./routes/items/[id].tsx": $19,
-    "./routes/notifications/[id].ts": $20,
-    "./routes/notifications/_middleware.ts": $21,
-    "./routes/notifications/index.tsx": $22,
-    "./routes/pricing.tsx": $23,
-    "./routes/signin.ts": $24,
-    "./routes/signout.ts": $25,
-    "./routes/submit/_middleware.tsx": $26,
-    "./routes/submit/index.tsx": $27,
-    "./routes/users/[login].tsx": $28,
+    "./routes/api/items/[id]/comments.ts": $8,
+    "./routes/api/stripe-webhooks.ts": $9,
+    "./routes/api/vote.ts": $10,
+    "./routes/blog/[slug].tsx": $11,
+    "./routes/blog/index.tsx": $12,
+    "./routes/callback.ts": $13,
+    "./routes/dashboard/_middleware.ts": $14,
+    "./routes/dashboard/index.tsx": $15,
+    "./routes/dashboard/stats.tsx": $16,
+    "./routes/dashboard/users.tsx": $17,
+    "./routes/feed.ts": $18,
+    "./routes/index.tsx": $19,
+    "./routes/items/[id].tsx": $20,
+    "./routes/notifications/[id].ts": $21,
+    "./routes/notifications/_middleware.ts": $22,
+    "./routes/notifications/index.tsx": $23,
+    "./routes/pricing.tsx": $24,
+    "./routes/signin.ts": $25,
+    "./routes/signout.ts": $26,
+    "./routes/submit/_middleware.tsx": $27,
+    "./routes/submit/index.tsx": $28,
+    "./routes/users/[login].tsx": $29,
   },
   islands: {
     "./islands/Chart.tsx": $$0,
-    "./islands/PageInput.tsx": $$1,
-    "./islands/VoteButton.tsx": $$2,
+    "./islands/CommentsList.tsx": $$1,
+    "./islands/PageInput.tsx": $$2,
+    "./islands/VoteButton.tsx": $$3,
   },
   baseUrl: import.meta.url,
 };

--- a/islands/CommentsList.tsx
+++ b/islands/CommentsList.tsx
@@ -24,7 +24,7 @@ function CommentSummary(props: Comment) {
 export default function CommentsList(props: { itemId: string }) {
   const commentsSig = useSignal<Comment[]>([]);
   const cursorSig = useSignal<string>("");
-  const observer = useRef<IntersectionObserver>();
+  const observerRef = useRef<IntersectionObserver>();
   const bottomRef = useRef<HTMLDivElement>(null);
 
   async function loadMoreComments() {
@@ -35,7 +35,7 @@ export default function CommentsList(props: { itemId: string }) {
       cursorSig.value,
     );
 
-    if (cursor === "") observer.current?.disconnect();
+    if (cursor === "") observerRef.current?.disconnect();
 
     commentsSig.value = [...commentsSig.value, ...comments];
     cursorSig.value = cursor;
@@ -50,20 +50,18 @@ export default function CommentsList(props: { itemId: string }) {
   }, []);
 
   useEffect(() => {
-    if (!observer.current) {
-      observer.current = new IntersectionObserver(([entry]) => {
+    if (!observerRef.current) {
+      observerRef.current = new IntersectionObserver(async ([entry]) => {
         if (entry.isIntersecting) {
-          loadMoreComments();
+          await loadMoreComments();
         }
       });
     }
 
-    if (cursorSig.value) {
-      observer.current.observe(bottomRef.current!);
-    }
+    observerRef.current.observe(bottomRef.current!);
 
     return () => {
-      observer.current?.disconnect();
+      observerRef.current?.disconnect();
     };
   }, [cursorSig.value]);
 

--- a/islands/CommentsList.tsx
+++ b/islands/CommentsList.tsx
@@ -7,6 +7,7 @@ import CommentSummary from "@/components/CommentSummary.tsx";
 async function fetchComments(itemId: string, cursor: string) {
   let url = `/api/items/${itemId}/comments`;
   if (cursor !== "") url += "?cursor=" + cursor;
+
   const resp = await fetch(url);
   if (!resp.ok) throw new Error(`Request failed: GET ${url}`);
   return await resp.json() as { comments: Comment[]; cursor: string };
@@ -35,7 +36,9 @@ export default function CommentsList(props: { itemId: string }) {
 
   return (
     <div>
-      {commentsSig.value.map((comment) => <CommentSummary {...comment} />)}
+      {commentsSig.value.map((comment) => (
+        <CommentSummary key={comment.id} {...comment} />
+      ))}
       <div ref={bottomRef}></div>
     </div>
   );

--- a/islands/CommentsList.tsx
+++ b/islands/CommentsList.tsx
@@ -1,71 +1,79 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { useSignal } from "@preact/signals";
-import { useCallback, useEffect, useRef } from "preact/hooks";
-import { Ref } from "preact";
+import { useEffect, useRef } from "preact/hooks";
 import { Comment } from "@/utils/db.ts";
 import UserPostedAt from "@/components/UserPostedAt.tsx";
 
 async function fetchComments(itemId: string, cursor: string) {
-  let url = `/api/items/${itemId}/comments`;
-  if (cursor !== "") url += "?cursor=" + cursor;
-
+  const url = `/api/items/${itemId}/comments${
+    cursor ? `?cursor=${cursor}` : ""
+  }`;
   const resp = await fetch(url);
   if (!resp.ok) throw new Error(`Request failed: GET ${url}`);
   return await resp.json() as { comments: Comment[]; cursor: string };
 }
 
+function CommentSummary(props: Comment) {
+  return (
+    <div class="py-4">
+      <UserPostedAt {...props} />
+      <p>{props.text}</p>
+    </div>
+  );
+}
+
 export default function CommentsList(props: { itemId: string }) {
   const commentsSig = useSignal<Comment[]>([]);
-  const cursorSig = useSignal("");
+  const cursorSig = useSignal<string>("");
   const observer = useRef<IntersectionObserver>();
-  const lastElementRef = useCallback((node: HTMLDivElement) => {
-    if (!cursorSig.value) return;
-    if (observer.current) observer.current.disconnect();
+  const lastElementRef = useRef<HTMLDivElement>(null);
 
-    observer.current = new IntersectionObserver(async ([entry]) => {
-      if (entry.isIntersecting) {
-        const { comments, cursor } = await fetchComments(
-          props.itemId,
-          cursorSig.value,
-        );
+  async function loadMoreComments() {
+    if (cursorSig.value === "") return;
 
-        if (cursor === "") observer.current?.unobserve(entry.target);
+    const { comments, cursor } = await fetchComments(
+      props.itemId,
+      cursorSig.value,
+    );
 
-        commentsSig.value = [...commentsSig.value, ...comments];
-        cursorSig.value = cursor;
-      }
-    });
+    if (cursor === "") observer.current?.disconnect();
 
-    if (node) observer.current.observe(node);
-  }, [cursorSig.value]);
+    commentsSig.value = [...commentsSig.value, ...comments];
+    cursorSig.value = cursor;
+  }
 
   useEffect(() => {
-    fetchComments(props.itemId, cursorSig.value).then(
-      ({ comments, cursor }) => {
+    fetchComments(props.itemId, cursorSig.value)
+      .then(({ comments, cursor }) => {
         commentsSig.value = comments;
         cursorSig.value = cursor;
-      },
-    );
+      });
   }, []);
+
+  useEffect(() => {
+    if (!observer.current) {
+      observer.current = new IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+          loadMoreComments();
+        }
+      });
+    }
+
+    if (cursorSig.value) {
+      observer.current.observe(lastElementRef.current!);
+    }
+
+    return () => {
+      observer.current?.disconnect();
+    };
+  }, [cursorSig.value]);
 
   return (
     <div>
-      {commentsSig.value.map((comment) => {
-        const isLast =
-          comment.id === commentsSig.value[commentsSig.value.length - 1].id;
-        const props = {
-          class: "py-4",
-          key: comment.id,
-          ref: isLast ? lastElementRef as Ref<HTMLDivElement> : null,
-        };
-
-        return (
-          <div {...props}>
-            <UserPostedAt {...comment} />
-            <p>{comment.text}</p>
-          </div>
-        );
-      })}
+      {commentsSig.value.map((comment) => (
+        <CommentSummary key={comment.id} {...comment} />
+      ))}
+      <div ref={lastElementRef} />
     </div>
   );
 }

--- a/islands/CommentsList.tsx
+++ b/islands/CommentsList.tsx
@@ -29,14 +29,11 @@ export default function CommentsList(props: { itemId: string }) {
 
   async function loadMoreComments() {
     if (cursorSig.value === "") return;
-
     const { comments, cursor } = await fetchComments(
       props.itemId,
       cursorSig.value,
     );
-
     if (cursor === "") observerRef.current?.disconnect();
-
     commentsSig.value = [...commentsSig.value, ...comments];
     cursorSig.value = cursor;
   }
@@ -52,17 +49,11 @@ export default function CommentsList(props: { itemId: string }) {
   useEffect(() => {
     if (!observerRef.current) {
       observerRef.current = new IntersectionObserver(async ([entry]) => {
-        if (entry.isIntersecting) {
-          await loadMoreComments();
-        }
+        if (entry.isIntersecting) await loadMoreComments();
       });
     }
-
     observerRef.current.observe(bottomRef.current!);
-
-    return () => {
-      observerRef.current?.disconnect();
-    };
+    return () => observerRef.current?.disconnect();
   }, [cursorSig.value]);
 
   return (

--- a/islands/CommentsList.tsx
+++ b/islands/CommentsList.tsx
@@ -5,9 +5,8 @@ import { Comment } from "@/utils/db.ts";
 import UserPostedAt from "@/components/UserPostedAt.tsx";
 
 async function fetchComments(itemId: string, cursor: string) {
-  const url = `/api/items/${itemId}/comments${
-    cursor ? `?cursor=${cursor}` : ""
-  }`;
+  let url = `/api/items/${itemId}/comments`;
+  if (cursor !== "") url += "?cursor=" + cursor;
   const resp = await fetch(url);
   if (!resp.ok) throw new Error(`Request failed: GET ${url}`);
   return await resp.json() as { comments: Comment[]; cursor: string };

--- a/islands/CommentsList.tsx
+++ b/islands/CommentsList.tsx
@@ -26,7 +26,7 @@ export default function CommentsList(props: { itemId: string }) {
   const commentsSig = useSignal<Comment[]>([]);
   const cursorSig = useSignal<string>("");
   const observer = useRef<IntersectionObserver>();
-  const lastElementRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
 
   async function loadMoreComments() {
     if (cursorSig.value === "") return;
@@ -60,7 +60,7 @@ export default function CommentsList(props: { itemId: string }) {
     }
 
     if (cursorSig.value) {
-      observer.current.observe(lastElementRef.current!);
+      observer.current.observe(bottomRef.current!);
     }
 
     return () => {
@@ -73,7 +73,7 @@ export default function CommentsList(props: { itemId: string }) {
       {commentsSig.value.map((comment) => (
         <CommentSummary key={comment.id} {...comment} />
       ))}
-      <div ref={lastElementRef} />
+      <div ref={bottomRef} />
     </div>
   );
 }

--- a/islands/CommentsList.tsx
+++ b/islands/CommentsList.tsx
@@ -1,0 +1,41 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import { Signal, useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import { Comment } from "@/utils/db.ts";
+import CommentSummary from "@/components/CommentSummary.tsx";
+
+async function getComments(itemId: string, cursor: string) {
+  let url = `/api/items/${itemId}/comments`;
+  if (cursor !== "") url += "?cursor=" + cursor;
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`Request failed: GET ${url}`);
+  return await resp.json() as { comments: Comment[]; cursor: string };
+}
+
+export default function CommentsList(props: { itemId: string }) {
+  const commentsSig: Signal<Comment[]> = useSignal([]);
+  const cursorSig = useSignal("");
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        getComments(props.itemId, cursorSig.value)
+          .then(({ comments, cursor }) => {
+            if (cursor === "") observer.unobserve(entry.target);
+            commentsSig.value = [...commentsSig.value, ...comments];
+            cursorSig.value = cursor;
+          });
+      }
+    });
+
+    observer.observe(document.querySelector("#bottom")!);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div>
+      {commentsSig.value.map((comment) => <CommentSummary {...comment} />)}
+      <div id="bottom"></div>
+    </div>
+  );
+}

--- a/routes/api/items/[id]/comments.ts
+++ b/routes/api/items/[id]/comments.ts
@@ -9,7 +9,7 @@ export default async function getCommentsByItem(
 ) {
   const iter = listCommentsByItem(ctx.params.id, {
     cursor: getCursor(ctx.url),
-    limit: 10,
+    limit: 1,
   });
   const comments = await valuesFromIter(iter);
   return Response.json({ comments, cursor: iter.cursor });

--- a/routes/api/items/[id]/comments.ts
+++ b/routes/api/items/[id]/comments.ts
@@ -1,3 +1,4 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { RouteContext } from "$fresh/server.ts";
 import { listCommentsByItem, valuesFromIter } from "@/utils/db.ts";
 import { getCursor } from "@/utils/pagination.ts";

--- a/routes/api/items/[id]/comments.ts
+++ b/routes/api/items/[id]/comments.ts
@@ -1,0 +1,15 @@
+import { RouteContext } from "$fresh/server.ts";
+import { listCommentsByItem, valuesFromIter } from "@/utils/db.ts";
+import { getCursor } from "@/utils/pagination.ts";
+
+export default async function getCommentsByItem(
+  _req: Request,
+  ctx: RouteContext,
+) {
+  const iter = listCommentsByItem(ctx.params.id, {
+    cursor: getCursor(ctx.url),
+    limit: 10,
+  });
+  const comments = await valuesFromIter(iter);
+  return Response.json({ comments, cursor: iter.cursor });
+}

--- a/routes/items/[id].tsx
+++ b/routes/items/[id].tsx
@@ -117,11 +117,12 @@ export default async function ItemsItemPage(
             />
           ))}
         </div>
-        <PaginationLink
-          url={ctx.url}
-          cursor={iter.cursor}
-          class="text-centre my-8"
-        />
+        <div class="text-center w-full">
+          <PaginationLink
+            url={ctx.url}
+            cursor={iter.cursor}
+          />
+        </div>
       </main>
     </>
   );

--- a/routes/items/[id].tsx
+++ b/routes/items/[id].tsx
@@ -96,6 +96,12 @@ export default async function ItemsItemPage(
   const iter = listCommentsByItem(itemId, { cursor });
   const comments = await valuesFromIter(iter);
 
+  console.log(iter.cursor);
+
+  /** @todo https://github.com/denoland/deno/issues/20173 */
+  const nextPageIter = listCommentsByItem(itemId, { cursor: iter.cursor });
+  const { done } = await nextPageIter.next();
+
   const [isVoted] = await getAreVotedBySessionId(
     [item],
     ctx.state.sessionId,
@@ -121,6 +127,7 @@ export default async function ItemsItemPage(
           <PaginationLink
             url={ctx.url}
             cursor={iter.cursor}
+            done={done}
           />
         </div>
       </main>

--- a/routes/items/[id].tsx
+++ b/routes/items/[id].tsx
@@ -9,17 +9,14 @@ import {
   getAreVotedBySessionId,
   getItem,
   getUserBySession,
-  listCommentsByItem,
   newCommentProps,
   newNotificationProps,
   Notification,
 } from "@/utils/db.ts";
-import UserPostedAt from "@/components/UserPostedAt.tsx";
 import { redirect } from "@/utils/redirect.ts";
 import Head from "@/components/Head.tsx";
 import { SignedInState } from "@/utils/middleware.ts";
-import PaginationLink from "@/components/PaginationLink.tsx";
-import { getCursor, getPagination } from "@/utils/pagination.ts";
+import CommentsList from "@/islands/CommentsList.tsx";
 
 export const handler: Handlers<unknown, SignedInState> = {
   async POST(req, ctx) {
@@ -75,15 +72,6 @@ function CommentInput() {
   );
 }
 
-function CommentSummary(props: Comment) {
-  return (
-    <div class="py-4">
-      <UserPostedAt {...props} />
-      <p>{props.text}</p>
-    </div>
-  );
-}
-
 export default async function ItemsItemPage(
   _req: Request,
   ctx: RouteContext<undefined, SignedInState>,
@@ -91,13 +79,6 @@ export default async function ItemsItemPage(
   const itemId = ctx.params.id;
   const item = await getItem(itemId);
   if (item === null) return await ctx.renderNotFound();
-
-  const limit = 10;
-  const iter = listCommentsByItem(itemId, {
-    cursor: getCursor(ctx.url),
-    limit: limit + 1,
-  });
-  const { cursor, values: comments, done } = await getPagination(iter, limit);
 
   const [isVoted] = await getAreVotedBySessionId(
     [item],
@@ -113,20 +94,7 @@ export default async function ItemsItemPage(
           isVoted={isVoted}
         />
         <CommentInput />
-        <div>
-          {comments.map((comment) => (
-            <CommentSummary
-              {...comment}
-            />
-          ))}
-        </div>
-        <div class="text-center w-full">
-          <PaginationLink
-            url={ctx.url}
-            cursor={cursor}
-            done={done}
-          />
-        </div>
+        <CommentsList itemId={ctx.params.id} />
       </main>
     </>
   );

--- a/routes/items/[id].tsx
+++ b/routes/items/[id].tsx
@@ -96,8 +96,6 @@ export default async function ItemsItemPage(
   const iter = listCommentsByItem(itemId, { cursor });
   const comments = await valuesFromIter(iter);
 
-  console.log(iter.cursor);
-
   /** @todo https://github.com/denoland/deno/issues/20173 */
   const nextPageIter = listCommentsByItem(itemId, { cursor: iter.cursor });
   const { done } = await nextPageIter.next();

--- a/tools/migrate_kv.ts
+++ b/tools/migrate_kv.ts
@@ -1,21 +1,13 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { kv, updateUser, User } from "@/utils/db.ts";
-
-type MaybeOldUser = User & {
-  id?: string;
-  avatarUrl?: string;
-};
+import { type Comment, createComment, kv } from "@/utils/db.ts";
 
 export async function migrateKv() {
   const promises = [];
-  const iter = kv.list<MaybeOldUser>({ prefix: ["users"] });
+  const iter = kv.list<Comment>({ prefix: ["comments_by_item"] });
   for await (const entry of iter) {
-    const user = entry.value;
-    if (user.id) {
-      promises.push(kv.delete(["users", user.id]));
-      delete user.id;
-      delete user.avatarUrl;
-      promises.push(updateUser(user));
+    if (entry.key.length === 3) {
+      promises.push(kv.delete(entry.key));
+      promises.push(createComment(entry.value));
     }
   }
   await Promise.all(promises);

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -329,7 +329,6 @@ export function listCommentsByItem(
   options?: Deno.KvListOptions,
 ) {
   return kv.list<Comment>({ prefix: ["comments_by_item", itemId] }, {
-    limit: 10,
     reverse: true,
     ...options,
   });

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -15,7 +15,6 @@ import {
   formatDate,
   getAllItems,
   getAreVotedBySessionId,
-  getCommentsByItem,
   getDatesSince,
   getItem,
   getItemsByUser,
@@ -30,6 +29,7 @@ import {
   ifUserHasNotifications,
   incrVisitsCountByDay,
   type Item,
+  listCommentsByItem,
   newCommentProps,
   newItemProps,
   newNotificationProps,
@@ -38,6 +38,7 @@ import {
   Notification,
   updateUser,
   type User,
+  valuesFromIter,
 } from "./db.ts";
 import {
   assert,
@@ -191,16 +192,19 @@ Deno.test("[db] (create/delete)Comment() + getCommentsByItem()", async () => {
   const comment1 = { ...genNewComment(), itemId };
   const comment2 = { ...genNewComment(), itemId };
 
-  assertEquals(await getCommentsByItem(itemId), []);
+  assertEquals(await valuesFromIter(listCommentsByItem(itemId)), []);
 
   await createComment(comment1);
   await createComment(comment2);
   await assertRejects(async () => await createComment(comment2));
-  assertArrayIncludes(await getCommentsByItem(itemId), [comment1, comment2]);
+  assertArrayIncludes(await valuesFromIter(listCommentsByItem(itemId)), [
+    comment1,
+    comment2,
+  ]);
 
   await deleteComment(comment1);
   await deleteComment(comment2);
-  assertEquals(await getCommentsByItem(itemId), []);
+  assertEquals(await valuesFromIter(listCommentsByItem(itemId)), []);
 });
 
 Deno.test("[db] votes", async () => {

--- a/utils/pagination.ts
+++ b/utils/pagination.ts
@@ -10,3 +10,27 @@ export function calcPageNum(url: URL) {
 export function calcLastPage(total = 0, pageLength = PAGE_LENGTH): number {
   return Math.ceil(total / pageLength);
 }
+
+export function getCursor(url: URL) {
+  return url.searchParams.get("cursor") ?? undefined;
+}
+
+export async function getPagination<T>(
+  iter: Deno.KvListIterator<T>,
+  limit: number,
+) {
+  const values: T[] = [];
+  let cursor = "";
+  let done = true;
+  for await (const entry of iter) {
+    if (values.length <= limit - 1) {
+      values.push(entry.value);
+      cursor = iter.cursor;
+    } else {
+      done = false;
+      break;
+    }
+  }
+
+  return { values, cursor, done };
+}


### PR DESCRIPTION
This is an alternative to #425, which uses a REST API and infinite scroll. I'd be interested to hear people's thoughts.

This method appears to work cleaner with Deno KV.

Towards #414

https://github.com/denoland/saaskit/assets/29347852/a521b84d-0180-497d-8d79-ca3d55d47bd4