### PR TITLE
feat: REST API for users

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -11,26 +11,29 @@ import * as $5 from "./routes/account/index.tsx";
 import * as $6 from "./routes/account/manage.ts";
 import * as $7 from "./routes/account/upgrade.ts";
 import * as $8 from "./routes/api/stripe-webhooks.ts";
-import * as $9 from "./routes/api/vote.ts";
-import * as $10 from "./routes/blog/[slug].tsx";
-import * as $11 from "./routes/blog/index.tsx";
-import * as $12 from "./routes/callback.ts";
-import * as $13 from "./routes/dashboard/_middleware.ts";
-import * as $14 from "./routes/dashboard/index.tsx";
-import * as $15 from "./routes/dashboard/stats.tsx";
-import * as $16 from "./routes/dashboard/users.tsx";
-import * as $17 from "./routes/feed.ts";
-import * as $18 from "./routes/index.tsx";
-import * as $19 from "./routes/items/[id].tsx";
-import * as $20 from "./routes/notifications/[id].ts";
-import * as $21 from "./routes/notifications/_middleware.ts";
-import * as $22 from "./routes/notifications/index.tsx";
-import * as $23 from "./routes/pricing.tsx";
-import * as $24 from "./routes/signin.ts";
-import * as $25 from "./routes/signout.ts";
-import * as $26 from "./routes/submit/_middleware.tsx";
-import * as $27 from "./routes/submit/index.tsx";
-import * as $28 from "./routes/users/[login].tsx";
+import * as $9 from "./routes/api/users/[login]/index.ts";
+import * as $10 from "./routes/api/users/[login]/items.ts";
+import * as $11 from "./routes/api/users/index.ts";
+import * as $12 from "./routes/api/vote.ts";
+import * as $13 from "./routes/blog/[slug].tsx";
+import * as $14 from "./routes/blog/index.tsx";
+import * as $15 from "./routes/callback.ts";
+import * as $16 from "./routes/dashboard/_middleware.ts";
+import * as $17 from "./routes/dashboard/index.tsx";
+import * as $18 from "./routes/dashboard/stats.tsx";
+import * as $19 from "./routes/dashboard/users.tsx";
+import * as $20 from "./routes/feed.ts";
+import * as $21 from "./routes/index.tsx";
+import * as $22 from "./routes/items/[id].tsx";
+import * as $23 from "./routes/notifications/[id].ts";
+import * as $24 from "./routes/notifications/_middleware.ts";
+import * as $25 from "./routes/notifications/index.tsx";
+import * as $26 from "./routes/pricing.tsx";
+import * as $27 from "./routes/signin.ts";
+import * as $28 from "./routes/signout.ts";
+import * as $29 from "./routes/submit/_middleware.tsx";
+import * as $30 from "./routes/submit/index.tsx";
+import * as $31 from "./routes/users/[login].tsx";
 import * as $$0 from "./islands/Chart.tsx";
 import * as $$1 from "./islands/PageInput.tsx";
 import * as $$2 from "./islands/VoteButton.tsx";
@@ -46,26 +49,29 @@ const manifest = {
     "./routes/account/manage.ts": $6,
     "./routes/account/upgrade.ts": $7,
     "./routes/api/stripe-webhooks.ts": $8,
-    "./routes/api/vote.ts": $9,
-    "./routes/blog/[slug].tsx": $10,
-    "./routes/blog/index.tsx": $11,
-    "./routes/callback.ts": $12,
-    "./routes/dashboard/_middleware.ts": $13,
-    "./routes/dashboard/index.tsx": $14,
-    "./routes/dashboard/stats.tsx": $15,
-    "./routes/dashboard/users.tsx": $16,
-    "./routes/feed.ts": $17,
-    "./routes/index.tsx": $18,
-    "./routes/items/[id].tsx": $19,
-    "./routes/notifications/[id].ts": $20,
-    "./routes/notifications/_middleware.ts": $21,
-    "./routes/notifications/index.tsx": $22,
-    "./routes/pricing.tsx": $23,
-    "./routes/signin.ts": $24,
-    "./routes/signout.ts": $25,
-    "./routes/submit/_middleware.tsx": $26,
-    "./routes/submit/index.tsx": $27,
-    "./routes/users/[login].tsx": $28,
+    "./routes/api/users/[login]/index.ts": $9,
+    "./routes/api/users/[login]/items.ts": $10,
+    "./routes/api/users/index.ts": $11,
+    "./routes/api/vote.ts": $12,
+    "./routes/blog/[slug].tsx": $13,
+    "./routes/blog/index.tsx": $14,
+    "./routes/callback.ts": $15,
+    "./routes/dashboard/_middleware.ts": $16,
+    "./routes/dashboard/index.tsx": $17,
+    "./routes/dashboard/stats.tsx": $18,
+    "./routes/dashboard/users.tsx": $19,
+    "./routes/feed.ts": $20,
+    "./routes/index.tsx": $21,
+    "./routes/items/[id].tsx": $22,
+    "./routes/notifications/[id].ts": $23,
+    "./routes/notifications/_middleware.ts": $24,
+    "./routes/notifications/index.tsx": $25,
+    "./routes/pricing.tsx": $26,
+    "./routes/signin.ts": $27,
+    "./routes/signout.ts": $28,
+    "./routes/submit/_middleware.tsx": $29,
+    "./routes/submit/index.tsx": $30,
+    "./routes/users/[login].tsx": $31,
   },
   islands: {
     "./islands/Chart.tsx": $$0,

--- a/routes/api/users/[login]/index.ts
+++ b/routes/api/users/[login]/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { Handlers, Status } from "$fresh/server.ts";
 import { getUser } from "@/utils/db.ts";
 

--- a/routes/api/users/[login]/index.ts
+++ b/routes/api/users/[login]/index.ts
@@ -1,0 +1,11 @@
+import { Handlers, Status } from "$fresh/server.ts";
+import { getUser } from "@/utils/db.ts";
+
+export const handler: Handlers = {
+  async GET(_req, ctx) {
+    const user = await getUser(ctx.params.login);
+    return user === null
+      ? new Response(null, { status: Status.NotFound })
+      : Response.json(user);
+  },
+};

--- a/routes/api/users/[login]/items.ts
+++ b/routes/api/users/[login]/items.ts
@@ -1,0 +1,18 @@
+import { Handlers, Status } from "$fresh/server.ts";
+import { collectValues, getUser, listItemsByUser } from "@/utils/db.ts";
+import { getCursor } from "@/utils/pagination.ts";
+
+export const handler: Handlers = {
+  async GET(req, ctx) {
+    const user = await getUser(ctx.params.login);
+    if (user === null) return new Response(null, { status: Status.NotFound });
+
+    const url = new URL(req.url);
+    const iter = listItemsByUser(ctx.params.login, {
+      cursor: getCursor(url),
+      limit: 10,
+    });
+    const items = await collectValues(iter);
+    return Response.json({ items, cursor: iter.cursor });
+  },
+};

--- a/routes/api/users/[login]/items.ts
+++ b/routes/api/users/[login]/items.ts
@@ -1,3 +1,4 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { Handlers, Status } from "$fresh/server.ts";
 import { collectValues, getUser, listItemsByUser } from "@/utils/db.ts";
 import { getCursor } from "@/utils/pagination.ts";

--- a/routes/api/users/index.ts
+++ b/routes/api/users/index.ts
@@ -1,0 +1,15 @@
+import type { Handlers } from "$fresh/server.ts";
+import { collectValues, listUsers } from "@/utils/db.ts";
+import { getCursor } from "@/utils/pagination.ts";
+
+export const handler: Handlers = {
+  async GET(req) {
+    const url = new URL(req.url);
+    const iter = listUsers({
+      cursor: getCursor(url),
+      limit: 10,
+    });
+    const users = await collectValues(iter);
+    return Response.json({ users, cursor: iter.cursor });
+  },
+};

--- a/routes/api/users/index.ts
+++ b/routes/api/users/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { Handlers } from "$fresh/server.ts";
 import { collectValues, listUsers } from "@/utils/db.ts";
 import { getCursor } from "@/utils/pagination.ts";

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -66,6 +66,12 @@ export function getDatesSince(msAgo: number) {
   return dates;
 }
 
+export async function collectValues<T>(iter: Deno.KvListIterator<T>) {
+  const values = [];
+  for await (const { value } of iter) values.push(value);
+  return values;
+}
+
 /** Converts `Date` to ISO format that is zero UTC offset */
 export function formatDate(date: Date) {
   return date.toISOString().split("T")[0];
@@ -146,6 +152,13 @@ export async function getItem(id: string) {
 
 export async function getItemsByUser(userLogin: string) {
   return await getValues<Item>({ prefix: ["items_by_user", userLogin] });
+}
+
+export function listItemsByUser(
+  userLogin: string,
+  options?: Deno.KvListOptions,
+) {
+  return kv.list<Item>({ prefix: ["items_by_user", userLogin] }, options);
 }
 
 export async function getAllItems() {
@@ -520,6 +533,10 @@ export async function getUserByStripeCustomer(stripeCustomerId: string) {
 
 export async function getUsers() {
   return await getValues<User>({ prefix: ["users"] });
+}
+
+export function listUsers(options?: Deno.KvListOptions) {
+  return kv.list<User>({ prefix: ["users"] }, options);
 }
 
 export async function getAreVotedBySessionId(

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -56,7 +56,7 @@ function genNewComment(): Comment {
   };
 }
 
-function genNewItem(): Item {
+export function genNewItem(): Item {
   return {
     userLogin: crypto.randomUUID(),
     title: crypto.randomUUID(),
@@ -65,7 +65,7 @@ function genNewItem(): Item {
   };
 }
 
-function genNewUser(): User {
+export function genNewUser(): User {
   return {
     login: crypto.randomUUID(),
     sessionId: crypto.randomUUID(),

--- a/utils/pagination.ts
+++ b/utils/pagination.ts
@@ -10,3 +10,7 @@ export function calcPageNum(url: URL) {
 export function calcLastPage(total = 0, pageLength = PAGE_LENGTH): number {
   return Math.ceil(total / pageLength);
 }
+
+export function getCursor(url: URL) {
+  return url.searchParams.get("cursor") ?? "";
+}


### PR DESCRIPTION
This change adds the following REST API endpoints.
- `GET /api/users`
- `GET /api/users/[login]`
- `GET /api/users/[login]/items`

Documentation will come in a follow-up PR.

Towards #439