### PR TITLE
feat: REST API for items and comments

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -10,30 +10,33 @@ import * as $4 from "./routes/account/_middleware.ts";
 import * as $5 from "./routes/account/index.tsx";
 import * as $6 from "./routes/account/manage.ts";
 import * as $7 from "./routes/account/upgrade.ts";
-import * as $8 from "./routes/api/stripe-webhooks.ts";
-import * as $9 from "./routes/api/users/[login]/index.ts";
-import * as $10 from "./routes/api/users/[login]/items.ts";
-import * as $11 from "./routes/api/users/index.ts";
-import * as $12 from "./routes/api/vote.ts";
-import * as $13 from "./routes/blog/[slug].tsx";
-import * as $14 from "./routes/blog/index.tsx";
-import * as $15 from "./routes/callback.ts";
-import * as $16 from "./routes/dashboard/_middleware.ts";
-import * as $17 from "./routes/dashboard/index.tsx";
-import * as $18 from "./routes/dashboard/stats.tsx";
-import * as $19 from "./routes/dashboard/users.tsx";
-import * as $20 from "./routes/feed.ts";
-import * as $21 from "./routes/index.tsx";
-import * as $22 from "./routes/items/[id].tsx";
-import * as $23 from "./routes/notifications/[id].ts";
-import * as $24 from "./routes/notifications/_middleware.ts";
-import * as $25 from "./routes/notifications/index.tsx";
-import * as $26 from "./routes/pricing.tsx";
-import * as $27 from "./routes/signin.ts";
-import * as $28 from "./routes/signout.ts";
-import * as $29 from "./routes/submit/_middleware.tsx";
-import * as $30 from "./routes/submit/index.tsx";
-import * as $31 from "./routes/users/[login].tsx";
+import * as $8 from "./routes/api/items/[id]/comments.ts";
+import * as $9 from "./routes/api/items/[id]/index.ts";
+import * as $10 from "./routes/api/items/index.ts";
+import * as $11 from "./routes/api/stripe-webhooks.ts";
+import * as $12 from "./routes/api/users/[login]/index.ts";
+import * as $13 from "./routes/api/users/[login]/items.ts";
+import * as $14 from "./routes/api/users/index.ts";
+import * as $15 from "./routes/api/vote.ts";
+import * as $16 from "./routes/blog/[slug].tsx";
+import * as $17 from "./routes/blog/index.tsx";
+import * as $18 from "./routes/callback.ts";
+import * as $19 from "./routes/dashboard/_middleware.ts";
+import * as $20 from "./routes/dashboard/index.tsx";
+import * as $21 from "./routes/dashboard/stats.tsx";
+import * as $22 from "./routes/dashboard/users.tsx";
+import * as $23 from "./routes/feed.ts";
+import * as $24 from "./routes/index.tsx";
+import * as $25 from "./routes/items/[id].tsx";
+import * as $26 from "./routes/notifications/[id].ts";
+import * as $27 from "./routes/notifications/_middleware.ts";
+import * as $28 from "./routes/notifications/index.tsx";
+import * as $29 from "./routes/pricing.tsx";
+import * as $30 from "./routes/signin.ts";
+import * as $31 from "./routes/signout.ts";
+import * as $32 from "./routes/submit/_middleware.tsx";
+import * as $33 from "./routes/submit/index.tsx";
+import * as $34 from "./routes/users/[login].tsx";
 import * as $$0 from "./islands/Chart.tsx";
 import * as $$1 from "./islands/PageInput.tsx";
 import * as $$2 from "./islands/VoteButton.tsx";
@@ -48,30 +51,33 @@ const manifest = {
     "./routes/account/index.tsx": $5,
     "./routes/account/manage.ts": $6,
     "./routes/account/upgrade.ts": $7,
-    "./routes/api/stripe-webhooks.ts": $8,
-    "./routes/api/users/[login]/index.ts": $9,
-    "./routes/api/users/[login]/items.ts": $10,
-    "./routes/api/users/index.ts": $11,
-    "./routes/api/vote.ts": $12,
-    "./routes/blog/[slug].tsx": $13,
-    "./routes/blog/index.tsx": $14,
-    "./routes/callback.ts": $15,
-    "./routes/dashboard/_middleware.ts": $16,
-    "./routes/dashboard/index.tsx": $17,
-    "./routes/dashboard/stats.tsx": $18,
-    "./routes/dashboard/users.tsx": $19,
-    "./routes/feed.ts": $20,
-    "./routes/index.tsx": $21,
-    "./routes/items/[id].tsx": $22,
-    "./routes/notifications/[id].ts": $23,
-    "./routes/notifications/_middleware.ts": $24,
-    "./routes/notifications/index.tsx": $25,
-    "./routes/pricing.tsx": $26,
-    "./routes/signin.ts": $27,
-    "./routes/signout.ts": $28,
-    "./routes/submit/_middleware.tsx": $29,
-    "./routes/submit/index.tsx": $30,
-    "./routes/users/[login].tsx": $31,
+    "./routes/api/items/[id]/comments.ts": $8,
+    "./routes/api/items/[id]/index.ts": $9,
+    "./routes/api/items/index.ts": $10,
+    "./routes/api/stripe-webhooks.ts": $11,
+    "./routes/api/users/[login]/index.ts": $12,
+    "./routes/api/users/[login]/items.ts": $13,
+    "./routes/api/users/index.ts": $14,
+    "./routes/api/vote.ts": $15,
+    "./routes/blog/[slug].tsx": $16,
+    "./routes/blog/index.tsx": $17,
+    "./routes/callback.ts": $18,
+    "./routes/dashboard/_middleware.ts": $19,
+    "./routes/dashboard/index.tsx": $20,
+    "./routes/dashboard/stats.tsx": $21,
+    "./routes/dashboard/users.tsx": $22,
+    "./routes/feed.ts": $23,
+    "./routes/index.tsx": $24,
+    "./routes/items/[id].tsx": $25,
+    "./routes/notifications/[id].ts": $26,
+    "./routes/notifications/_middleware.ts": $27,
+    "./routes/notifications/index.tsx": $28,
+    "./routes/pricing.tsx": $29,
+    "./routes/signin.ts": $30,
+    "./routes/signout.ts": $31,
+    "./routes/submit/_middleware.tsx": $32,
+    "./routes/submit/index.tsx": $33,
+    "./routes/users/[login].tsx": $34,
   },
   islands: {
     "./islands/Chart.tsx": $$0,

--- a/routes/api/items/[id]/comments.ts
+++ b/routes/api/items/[id]/comments.ts
@@ -1,0 +1,22 @@
+import { Handlers, Status } from "$fresh/server.ts";
+import { collectValues, getItem, listCommentsByItem } from "@/utils/db.ts";
+import { getCursor } from "@/utils/pagination.ts";
+
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+export const handler: Handlers = {
+  async GET(req, ctx) {
+    const itemId = ctx.params.id;
+    const item = await getItem(itemId);
+    if (item === null) return new Response(null, { status: Status.NotFound });
+
+    const url = new URL(req.url);
+    const iter = listCommentsByItem(itemId, {
+      cursor: getCursor(url),
+      limit: 10,
+      // Newest to oldest
+      reverse: true,
+    });
+    const comments = await collectValues(iter);
+    return Response.json({ comments, cursor: iter.cursor });
+  },
+};

--- a/routes/api/items/[id]/index.ts
+++ b/routes/api/items/[id]/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import { type Handlers, Status } from "$fresh/server.ts";
+import { getItem } from "@/utils/db.ts";
+
+export const handler: Handlers = {
+  async GET(_req, ctx) {
+    const item = await getItem(ctx.params.id);
+    return item === null
+      ? new Response(null, { status: Status.NotFound })
+      : Response.json(item);
+  },
+};

--- a/routes/api/items/index.ts
+++ b/routes/api/items/index.ts
@@ -1,0 +1,17 @@
+import { Handlers } from "$fresh/server.ts";
+import { collectValues, listItemsByTime } from "@/utils/db.ts";
+import { getCursor } from "@/utils/pagination.ts";
+
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+export const handler: Handlers = {
+  async GET(req) {
+    const url = new URL(req.url);
+    const iter = listItemsByTime({
+      cursor: getCursor(url),
+      limit: 10,
+      reverse: true,
+    });
+    const items = await collectValues(iter);
+    return Response.json({ items, cursor: iter.cursor });
+  },
+};

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -161,6 +161,10 @@ export function listItemsByUser(
   return kv.list<Item>({ prefix: ["items_by_user", userLogin] }, options);
 }
 
+export function listItemsByTime(options?: Deno.KvListOptions) {
+  return kv.list<Item>({ prefix: ["items_by_time"] }, options);
+}
+
 export async function getAllItems() {
   return await getValues<Item>({ prefix: ["items"] });
 }
@@ -301,7 +305,12 @@ export function newCommentProps(): Pick<Comment, "id" | "createdAt"> {
 }
 
 export async function createComment(comment: Comment) {
-  const commentsByItemKey = ["comments_by_item", comment.itemId, comment.id];
+  const commentsByItemKey = [
+    "comments_by_item",
+    comment.itemId,
+    comment.createdAt.getTime(),
+    comment.id,
+  ];
 
   const res = await kv.atomic()
     .check({ key: commentsByItemKey, versionstamp: null })
@@ -312,7 +321,12 @@ export async function createComment(comment: Comment) {
 }
 
 export async function deleteComment(comment: Comment) {
-  const commentsByItemKey = ["comments_by_item", comment.itemId, comment.id];
+  const commentsByItemKey = [
+    "comments_by_item",
+    comment.itemId,
+    comment.createdAt.getTime(),
+    comment.id,
+  ];
 
   const res = await kv.atomic()
     .delete(commentsByItemKey)
@@ -323,6 +337,13 @@ export async function deleteComment(comment: Comment) {
 
 export async function getCommentsByItem(itemId: string) {
   return await getValues<Comment>({ prefix: ["comments_by_item", itemId] });
+}
+
+export function listCommentsByItem(
+  itemId: string,
+  options?: Deno.KvListOptions,
+) {
+  return kv.list<Comment>({ prefix: ["comments_by_item", itemId] }, options);
 }
 
 // Vote

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -47,7 +47,7 @@ import {
 } from "std/testing/asserts.ts";
 import { DAY } from "std/datetime/constants.ts";
 
-function genNewComment(): Comment {
+export function genNewComment(): Comment {
   return {
     itemId: crypto.randomUUID(),
     userLogin: crypto.randomUUID(),


### PR DESCRIPTION
This change adds the following REST API endpoints:
- `GET /api/items`
- `GET /api/items/[id]`
- `GET /api/items/[id]/comments`

Documentation will come in a follow-up PR.

Prerequisite for #438 or #429
Towards #439