### PR TITLE
feat: REST API and cursor-based pagination for notifications

### DIFF
--- a/e2e_test.ts
+++ b/e2e_test.ts
@@ -11,13 +11,20 @@ import {
   assertNotEquals,
   assertStringIncludes,
 } from "std/testing/asserts.ts";
-import { genNewComment, genNewItem, genNewUser } from "@/utils/db_test.ts";
+import {
+  genNewComment,
+  genNewItem,
+  genNewNotification,
+  genNewUser,
+} from "@/utils/db_test.ts";
 import {
   type Comment,
   createComment,
   createItem,
+  createNotification,
   createUser,
   type Item,
+  type Notification,
 } from "@/utils/db.ts";
 
 function assertResponseNotFound(resp: Response) {
@@ -274,5 +281,29 @@ Deno.test("[http]", async (test) => {
     const { items } = await resp2.json();
     assertResponseJson(resp2);
     assertArrayIncludes(items, [JSON.parse(JSON.stringify(item))]);
+  });
+
+  await test.step("GET /api/users/[login]/notifications", async () => {
+    const user = genNewUser();
+    const notification: Notification = {
+      ...genNewNotification(),
+      userLogin: user.login,
+    };
+    const req = new Request(
+      `http://localhost/api/users/${user.login}/notifications`,
+    );
+
+    const resp1 = await handler(req);
+    assertResponseNotFound(resp1);
+
+    await createUser(user);
+    await createNotification(notification);
+
+    const resp2 = await handler(req);
+    const { notifications } = await resp2.json();
+    assertResponseJson(resp2);
+    assertArrayIncludes(notifications, [
+      JSON.parse(JSON.stringify(notification)),
+    ]);
   });
 });

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -16,31 +16,33 @@ import * as $10 from "./routes/api/items/index.ts";
 import * as $11 from "./routes/api/stripe-webhooks.ts";
 import * as $12 from "./routes/api/users/[login]/index.ts";
 import * as $13 from "./routes/api/users/[login]/items.ts";
-import * as $14 from "./routes/api/users/index.ts";
-import * as $15 from "./routes/api/vote.ts";
-import * as $16 from "./routes/blog/[slug].tsx";
-import * as $17 from "./routes/blog/index.tsx";
-import * as $18 from "./routes/callback.ts";
-import * as $19 from "./routes/dashboard/_middleware.ts";
-import * as $20 from "./routes/dashboard/index.tsx";
-import * as $21 from "./routes/dashboard/stats.tsx";
-import * as $22 from "./routes/dashboard/users.tsx";
-import * as $23 from "./routes/feed.ts";
-import * as $24 from "./routes/index.tsx";
-import * as $25 from "./routes/items/[id].tsx";
-import * as $26 from "./routes/notifications/[id].ts";
-import * as $27 from "./routes/notifications/_middleware.ts";
-import * as $28 from "./routes/notifications/index.tsx";
-import * as $29 from "./routes/pricing.tsx";
-import * as $30 from "./routes/signin.ts";
-import * as $31 from "./routes/signout.ts";
-import * as $32 from "./routes/submit/_middleware.tsx";
-import * as $33 from "./routes/submit/index.tsx";
-import * as $34 from "./routes/users/[login].tsx";
+import * as $14 from "./routes/api/users/[login]/notifications.ts";
+import * as $15 from "./routes/api/users/index.ts";
+import * as $16 from "./routes/api/vote.ts";
+import * as $17 from "./routes/blog/[slug].tsx";
+import * as $18 from "./routes/blog/index.tsx";
+import * as $19 from "./routes/callback.ts";
+import * as $20 from "./routes/dashboard/_middleware.ts";
+import * as $21 from "./routes/dashboard/index.tsx";
+import * as $22 from "./routes/dashboard/stats.tsx";
+import * as $23 from "./routes/dashboard/users.tsx";
+import * as $24 from "./routes/feed.ts";
+import * as $25 from "./routes/index.tsx";
+import * as $26 from "./routes/items/[id].tsx";
+import * as $27 from "./routes/notifications/[id].ts";
+import * as $28 from "./routes/notifications/_middleware.ts";
+import * as $29 from "./routes/notifications/index.tsx";
+import * as $30 from "./routes/pricing.tsx";
+import * as $31 from "./routes/signin.ts";
+import * as $32 from "./routes/signout.ts";
+import * as $33 from "./routes/submit/_middleware.tsx";
+import * as $34 from "./routes/submit/index.tsx";
+import * as $35 from "./routes/users/[login].tsx";
 import * as $$0 from "./islands/Chart.tsx";
 import * as $$1 from "./islands/CommentsList.tsx";
-import * as $$2 from "./islands/PageInput.tsx";
-import * as $$3 from "./islands/VoteButton.tsx";
+import * as $$2 from "./islands/NotificationsList.tsx";
+import * as $$3 from "./islands/PageInput.tsx";
+import * as $$4 from "./islands/VoteButton.tsx";
 
 const manifest = {
   routes: {
@@ -58,33 +60,35 @@ const manifest = {
     "./routes/api/stripe-webhooks.ts": $11,
     "./routes/api/users/[login]/index.ts": $12,
     "./routes/api/users/[login]/items.ts": $13,
-    "./routes/api/users/index.ts": $14,
-    "./routes/api/vote.ts": $15,
-    "./routes/blog/[slug].tsx": $16,
-    "./routes/blog/index.tsx": $17,
-    "./routes/callback.ts": $18,
-    "./routes/dashboard/_middleware.ts": $19,
-    "./routes/dashboard/index.tsx": $20,
-    "./routes/dashboard/stats.tsx": $21,
-    "./routes/dashboard/users.tsx": $22,
-    "./routes/feed.ts": $23,
-    "./routes/index.tsx": $24,
-    "./routes/items/[id].tsx": $25,
-    "./routes/notifications/[id].ts": $26,
-    "./routes/notifications/_middleware.ts": $27,
-    "./routes/notifications/index.tsx": $28,
-    "./routes/pricing.tsx": $29,
-    "./routes/signin.ts": $30,
-    "./routes/signout.ts": $31,
-    "./routes/submit/_middleware.tsx": $32,
-    "./routes/submit/index.tsx": $33,
-    "./routes/users/[login].tsx": $34,
+    "./routes/api/users/[login]/notifications.ts": $14,
+    "./routes/api/users/index.ts": $15,
+    "./routes/api/vote.ts": $16,
+    "./routes/blog/[slug].tsx": $17,
+    "./routes/blog/index.tsx": $18,
+    "./routes/callback.ts": $19,
+    "./routes/dashboard/_middleware.ts": $20,
+    "./routes/dashboard/index.tsx": $21,
+    "./routes/dashboard/stats.tsx": $22,
+    "./routes/dashboard/users.tsx": $23,
+    "./routes/feed.ts": $24,
+    "./routes/index.tsx": $25,
+    "./routes/items/[id].tsx": $26,
+    "./routes/notifications/[id].ts": $27,
+    "./routes/notifications/_middleware.ts": $28,
+    "./routes/notifications/index.tsx": $29,
+    "./routes/pricing.tsx": $30,
+    "./routes/signin.ts": $31,
+    "./routes/signout.ts": $32,
+    "./routes/submit/_middleware.tsx": $33,
+    "./routes/submit/index.tsx": $34,
+    "./routes/users/[login].tsx": $35,
   },
   islands: {
     "./islands/Chart.tsx": $$0,
     "./islands/CommentsList.tsx": $$1,
-    "./islands/PageInput.tsx": $$2,
-    "./islands/VoteButton.tsx": $$3,
+    "./islands/NotificationsList.tsx": $$2,
+    "./islands/PageInput.tsx": $$3,
+    "./islands/VoteButton.tsx": $$4,
   },
   baseUrl: import.meta.url,
 };

--- a/islands/NotificationsList.tsx
+++ b/islands/NotificationsList.tsx
@@ -1,0 +1,72 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import type { Notification } from "@/utils/db.ts";
+import { LINK_STYLES } from "@/utils/constants.ts";
+import { timeAgo } from "@/utils/display.ts";
+
+async function fetchNotifications(userLogin: string, cursor: string) {
+  let url = `/api/users/${userLogin}/notifications`;
+  if (cursor !== "" && cursor !== undefined) url += "?cursor=" + cursor;
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`Request failed: GET ${url}`);
+  return await resp.json() as { notifications: Notification[]; cursor: string };
+}
+
+function NotificationSummary(props: Notification) {
+  return (
+    <li class="py-4 space-y-1">
+      <a href={"/notifications/" + props.id}>
+        <span class="mr-4">
+          <strong>New {props.type}!</strong>
+        </span>
+        <span class="text-gray-500">
+          {" " + timeAgo(props.createdAt)} ago
+        </span>
+        <br />
+        <span>{props.text}</span>
+      </a>
+    </li>
+  );
+}
+
+export default function NotificationsList(props: { userLogin: string }) {
+  const notificationsSig = useSignal<Notification[]>([]);
+  const cursorSig = useSignal("");
+  const isLoadingSig = useSignal(false);
+
+  async function loadMoreNotifications() {
+    isLoadingSig.value = true;
+    try {
+      const { notifications, cursor } = await fetchNotifications(
+        props.userLogin,
+        cursorSig.value,
+      );
+      notificationsSig.value = [...notificationsSig.value, ...notifications];
+      cursorSig.value = cursor;
+    } catch (error) {
+      console.log(error.message);
+    } finally {
+      isLoadingSig.value = false;
+    }
+  }
+
+  useEffect(() => {
+    loadMoreNotifications();
+  }, []);
+
+  return (
+    <div>
+      {notificationsSig.value.length > 0
+        ? notificationsSig.value?.map((notification) => (
+          <NotificationSummary key={notification.id} {...notification} />
+        ))
+        : "Nothing notifications yet"}
+      {cursorSig.value !== "" && !isLoadingSig.value && (
+        <button onClick={loadMoreNotifications} class={LINK_STYLES}>
+          Load more
+        </button>
+      )}
+    </div>
+  );
+}

--- a/islands/NotificationsList.tsx
+++ b/islands/NotificationsList.tsx
@@ -61,7 +61,7 @@ export default function NotificationsList(props: { userLogin: string }) {
         ? notificationsSig.value?.map((notification) => (
           <NotificationSummary key={notification.id} {...notification} />
         ))
-        : "Nothing notifications yet"}
+        : "No notifications yet"}
       {cursorSig.value !== "" && !isLoadingSig.value && (
         <button onClick={loadMoreNotifications} class={LINK_STYLES}>
           Load more

--- a/routes/api/users/[login]/notifications.ts
+++ b/routes/api/users/[login]/notifications.ts
@@ -1,0 +1,21 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import { type Handlers, Status } from "$fresh/server.ts";
+import { collectValues, getUser, listNotificationsByUser } from "@/utils/db.ts";
+import { getCursor } from "@/utils/pagination.ts";
+
+export const handler: Handlers = {
+  async GET(req, ctx) {
+    const user = await getUser(ctx.params.login);
+    if (user === null) return new Response(null, { status: Status.NotFound });
+
+    const url = new URL(req.url);
+    const iter = listNotificationsByUser(user.login, {
+      cursor: getCursor(url),
+      limit: 10,
+      // Newest to oldest
+      reverse: true,
+    });
+    const notifications = await collectValues(iter);
+    return Response.json({ notifications, cursor: iter.cursor });
+  },
+};

--- a/routes/notifications/index.tsx
+++ b/routes/notifications/index.tsx
@@ -1,50 +1,21 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { RouteContext } from "$fresh/server.ts";
-import { getNotificationsByUser, Notification } from "@/utils/db.ts";
-import { timeAgo } from "@/utils/display.ts";
 import Head from "@/components/Head.tsx";
 import type { SignedInState } from "@/utils/middleware.ts";
-import { HEADING_STYLES } from "@/utils/constants.ts";
+import { HEADING_WITH_MARGIN_STYLES } from "@/utils/constants.ts";
+import NotificationsList from "@/islands/NotificationsList.tsx";
 
-function compareCreatedAt(a: Notification, b: Notification) {
-  return Number(b.createdAt) - Number(a.createdAt);
-}
-
-function Row(props: Notification) {
-  return (
-    <li class="py-4 space-y-1">
-      <a href={"/notifications/" + props.id}>
-        <span class="mr-4">
-          <strong>New {props.type}!</strong>
-        </span>
-        <span class="text-gray-500">
-          {" " + timeAgo(props.createdAt)} ago
-        </span>
-        <br />
-        <span>{props.text}</span>
-      </a>
-    </li>
-  );
-}
-
+// deno-lint-ignore require-await
 export default async function NotificationsPage(
   _req: Request,
   ctx: RouteContext<undefined, SignedInState>,
 ) {
-  const notifications = await getNotificationsByUser(ctx.state.user.login);
-
   return (
     <>
       <Head title="Notifications" href={ctx.url.href} />
       <main class="flex-1 p-4">
-        <h1 class={HEADING_STYLES}>Notifications</h1>
-        <ul class="divide-y">
-          {notifications.length > 0
-            ? notifications
-              .toSorted(compareCreatedAt)
-              .map((notification) => <Row {...notification} />)
-            : "No notifications yet"}
-        </ul>
+        <h1 class={HEADING_WITH_MARGIN_STYLES}>Notifications</h1>
+        <NotificationsList userLogin={ctx.state.user.login} />
       </main>
     </>
   );

--- a/tools/migrate_kv.ts
+++ b/tools/migrate_kv.ts
@@ -1,15 +1,10 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { type Comment, createComment, kv } from "@/utils/db.ts";
+import { kv } from "@/utils/db.ts";
 
 export async function migrateKv() {
   const promises = [];
-  const iter = kv.list<Comment>({ prefix: ["comments_by_item"] });
-  for await (const entry of iter) {
-    if (entry.key.length === 3) {
-      promises.push(kv.delete(entry.key));
-      promises.push(createComment(entry.value));
-    }
-  }
+  const iter = kv.list({ prefix: ["notifications_by_user"] });
+  for await (const { key } of iter) promises.push(kv.delete(key));
   await Promise.all(promises);
   console.log("KV migration complete");
 }

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -236,6 +236,7 @@ export async function createNotification(notification: Notification) {
   const notificationsByUserKey = [
     "notifications_by_user",
     notification.userLogin,
+    notification.createdAt.getTime(),
     notification.id,
   ];
 
@@ -256,6 +257,7 @@ export async function deleteNotification(notification: Notification) {
   const notificationsByUserKey = [
     "notifications_by_user",
     notification.userLogin,
+    notification.createdAt.getTime(),
     notification.id,
   ];
 
@@ -273,10 +275,13 @@ export async function getNotification(id: string) {
   return await getValue<Notification>(["notifications", id]);
 }
 
-export async function getNotificationsByUser(userLogin: string) {
-  return await getValues<Notification>({
+export function listNotificationsByUser(
+  userLogin: string,
+  options?: Deno.KvListOptions,
+) {
+  return kv.list<Notification>({
     prefix: ["notifications_by_user", userLogin],
-  });
+  }, options);
 }
 
 export async function ifUserHasNotifications(userLogin: string) {

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -75,7 +75,7 @@ export function genNewUser(): User {
   };
 }
 
-function genNewNotification(): Notification {
+export function genNewNotification(): Notification {
   return {
     userLogin: crypto.randomUUID(),
     type: crypto.randomUUID(),

--- a/utils/db_test.ts
+++ b/utils/db_test.ts
@@ -22,7 +22,6 @@ import {
   getItemsSince,
   getManyMetrics,
   getNotification,
-  getNotificationsByUser,
   getUser,
   getUserBySession,
   getUserByStripeCustomer,
@@ -31,6 +30,7 @@ import {
   incrVisitsCountByDay,
   type Item,
   listCommentsByItem,
+  listNotificationsByUser,
   newCommentProps,
   newItemProps,
   newNotificationProps,
@@ -279,12 +279,12 @@ Deno.test("[db] getNotificationsByUser()", async () => {
   const notification1 = { ...genNewNotification(), userLogin };
   const notification2 = { ...genNewNotification(), userLogin };
 
-  assertEquals(await getNotificationsByUser(userLogin), []);
+  assertEquals(await collectValues(listNotificationsByUser(userLogin)), []);
   assertEquals(await ifUserHasNotifications(userLogin), false);
 
   await createNotification(notification1);
   await createNotification(notification2);
-  assertArrayIncludes(await getNotificationsByUser(userLogin), [
+  assertArrayIncludes(await collectValues(listNotificationsByUser(userLogin)), [
     notification1,
     notification2,
   ]);


### PR DESCRIPTION
This change adds the `GET /api/users/[login]/notifications` REST API endpoint.

Documentation will come in a follow-up PR.

Towards #439 and #414