### PR TITLE
feat: add URL validation

### DIFF
--- a/routes/submit/index.tsx
+++ b/routes/submit/index.tsx
@@ -12,6 +12,7 @@ import Head from "@/components/Head.tsx";
 import IconCheckCircle from "tabler_icons_tsx/circle-check.tsx";
 import IconCircleX from "tabler_icons_tsx/circle-x.tsx";
 import { SignedInState } from "@/utils/middleware.ts";
+import { isPublicUrl, isValidUrl } from "@/utils/url_validation.ts";
 
 export const handler: Handlers<SignedInState, SignedInState> = {
   async POST(req, ctx) {
@@ -24,8 +25,9 @@ export const handler: Handlers<SignedInState, SignedInState> = {
     }
 
     try {
-      // Throws if an invalid URL
-      new URL(url);
+      if (!isValidUrl(url) || !isPublicUrl(url)) {
+        return new Response(null, { status: 400 });
+      }
     } catch {
       return new Response(null, { status: 400 });
     }

--- a/utils/url_validation.ts
+++ b/utils/url_validation.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
 
 export function isValidUrl(string: string): boolean {
   return URL.canParse(string) && string.startsWith("http");

--- a/utils/url_validation.ts
+++ b/utils/url_validation.ts
@@ -1,14 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 export function isValidUrl(string: string): boolean {
-  try {
-    const { protocol } = new URL(string);
-    const pattern = /^(https?):/
-
-    return pattern.test(protocol);
-  } catch (_) {
-    return false;
-  }
+  return URL.canParse(string) && string.startsWith("http");
 }
 
 export function isPublicUrl(string: string): boolean {

--- a/utils/url_validation.ts
+++ b/utils/url_validation.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
 export function isValidUrl(string: string): boolean {
   try {
     const { protocol } = new URL(string);

--- a/utils/url_validation.ts
+++ b/utils/url_validation.ts
@@ -21,5 +21,4 @@ export function isPublicUrl(string: string): boolean {
   } catch (_) {
     return false;
   }
-  
 }

--- a/utils/url_validation.ts
+++ b/utils/url_validation.ts
@@ -1,7 +1,12 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 
 export function isValidUrl(string: string): boolean {
-  return URL.canParse(string) && string.startsWith("http");
+  try {
+    const { protocol } = new URL(string);
+    return protocol.startsWith("http");
+  } catch {
+    return false;
+  }
 }
 
 export function isPublicUrl(string: string): boolean {

--- a/utils/url_validation.ts
+++ b/utils/url_validation.ts
@@ -1,0 +1,30 @@
+export function isValidUrl(string: string): boolean {
+  try {
+    const { protocol } = new URL(string);
+    const pattern = /^(https?):/
+
+    return pattern.test(protocol);
+  } catch (_) {
+    return false;
+  }
+}
+
+export function isPublicUrl(string: string): boolean {
+  try {
+    const { hostname } = new URL(string);
+    const ranges = [
+      /^localhost$/,
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
+      /^::1$/,
+      /^0:0:0:0:0:0:0:1$/,
+      /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
+      /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/,
+      /^192\.168\.\d{1,3}\.\d{1,3}$/,
+    ];
+
+    return !ranges.some((range) => range.test(hostname));
+  } catch (_) {
+    return false;
+  }
+  
+}

--- a/utils/url_validation_test.ts
+++ b/utils/url_validation_test.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
 import { assertEquals } from "std/testing/asserts.ts";
 import { isPublicUrl, isValidUrl } from "./url_validation.ts";
 

--- a/utils/url_validation_test.ts
+++ b/utils/url_validation_test.ts
@@ -9,7 +9,7 @@ Deno.test("[url_validation] isValidUrl()", () => {
   assertEquals(isValidUrl("ws://hunt.deno.land/"), false);
   assertEquals(isValidUrl("wss://hunt.deno.land/"), false);
   assertEquals(isValidUrl("invalidurl"), false);
-})
+});
 
 Deno.test("[url_validation] isPublicUrl()", () => {
   assertEquals(isPublicUrl("https://hunt.deno.land/"), true);
@@ -21,4 +21,4 @@ Deno.test("[url_validation] isPublicUrl()", () => {
   assertEquals(isPublicUrl("http://10.0.0.0/"), false);
   assertEquals(isPublicUrl("http://172.16.0.0/"), false);
   assertEquals(isPublicUrl("http://192.168.0.0/"), false);
-})
+});

--- a/utils/url_validation_test.ts
+++ b/utils/url_validation_test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "std/testing/asserts.ts";
+import { isPublicUrl, isValidUrl } from "./url_validation.ts";
+
+Deno.test("[url_validation] isValidUrl()", () => {
+  assertEquals(isValidUrl("https://hunt.deno.land/"), true);
+  assertEquals(isValidUrl("http://hunt.deno.land/"), true);
+  assertEquals(isValidUrl("ws://hunt.deno.land/"), false);
+  assertEquals(isValidUrl("wss://hunt.deno.land/"), false);
+  assertEquals(isValidUrl("invalidurl"), false);
+})
+
+Deno.test("[url_validation] isPublicUrl()", () => {
+  assertEquals(isPublicUrl("https://hunt.deno.land/"), true);
+  assertEquals(isPublicUrl("http://hunt.deno.land/"), true);
+  assertEquals(isPublicUrl("ws://hunt.deno.land/"), true);
+  assertEquals(isPublicUrl("http://localhost/"), false);
+  assertEquals(isPublicUrl("http://127.0.0.1/"), false);
+  assertEquals(isPublicUrl("http://::1/"), false);
+  assertEquals(isPublicUrl("http://10.0.0.0/"), false);
+  assertEquals(isPublicUrl("http://172.16.0.0/"), false);
+  assertEquals(isPublicUrl("http://192.168.0.0/"), false);
+})

--- a/utils/url_validation_test.ts
+++ b/utils/url_validation_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
 
 import { assertEquals } from "std/testing/asserts.ts";
 import { isPublicUrl, isValidUrl } from "./url_validation.ts";


### PR DESCRIPTION
closes #378.  

adds some naive url validations to the submit route.  
adds some tests for these naive validations.

these validations check that:
- the urls start w/ `http:` or `https:`
- the urls don't use local ip addresses and/or `localhost`
