### PR TITLE
feat: disallow duplicate entries for users

### DIFF
--- a/routes/submit/index.tsx
+++ b/routes/submit/index.tsx
@@ -22,25 +22,25 @@ export const handler: Handlers<SignedInState, SignedInState> = {
     const url = form.get("url");
 
     if (typeof title !== "string" || typeof url !== "string") {
-      return new Response(null, { status: 400 });
+      return new Response("URL or Title are either invalid or missing.", { status: 400 });
     }
 
     try {
       if (!isValidUrl(url) || !isPublicUrl(url)) {
-        return new Response(null, { status: 400 });
+        return new Response("URL must be valid and publicly available.", { status: 400 });
       }
     } catch {
-      return new Response(null, { status: 400 });
+      return new Response("An Error occured while validating the URL.", { status: 500 });
     }
 
     const user = await getUserBySession(ctx.state.sessionId);
 
-    if (!user) return new Response(null, { status: 400 });
+    if (!user) return new Response("You must be logged in to submit a new Item.", { status: 401 });
 
     const items = await getItemsByUser(user.login);
 
     if (items.some((item) => item.url === url || item.title === title)) {
-      return new Response(null, { status: 400 });
+      return new Response("You already submitted an Item which contains the same Title or URL.", { status: 409 });
     }
 
     const item: Item = {

--- a/routes/submit/index.tsx
+++ b/routes/submit/index.tsx
@@ -22,27 +22,27 @@ export const handler: Handlers<SignedInState, SignedInState> = {
     const url = form.get("url");
 
     if (typeof title !== "string" || typeof url !== "string") {
-      return new Response("URL or Title are either invalid or missing.", {
+      return new Response("Item URL or title are either invalid or missing.", {
         status: 400,
       });
     }
 
     try {
       if (!isValidUrl(url) || !isPublicUrl(url)) {
-        return new Response("URL must be valid and publicly available.", {
+        return new Response("Item URL must be valid and publicly available.", {
           status: 400,
         });
       }
     } catch {
-      return new Response("An Error occurred while validating the URL.", {
+      return new Response("An error occurred while validating the URL.", {
         status: 500,
       });
     }
 
     const user = await getUserBySession(ctx.state.sessionId);
 
-    if (!user) {
-      return new Response("You must be logged in to submit a new Item.", {
+    if (user === null) {
+      return new Response("You must be logged in to submit a new item.", {
         status: 401,
       });
     }
@@ -51,7 +51,7 @@ export const handler: Handlers<SignedInState, SignedInState> = {
 
     if (items.some((item) => item.url === url || item.title === title)) {
       return new Response(
-        "You already submitted an Item which contains the same Title or URL.",
+        "You already submitted an item which contains the same title or URL.",
         { status: 409 },
       );
     }

--- a/routes/submit/index.tsx
+++ b/routes/submit/index.tsx
@@ -3,6 +3,7 @@ import type { Handlers, PageProps } from "$fresh/server.ts";
 import { HEADING_STYLES, INPUT_STYLES } from "@/utils/constants.ts";
 import {
   createItem,
+  getItemsByUser,
   getUserBySession,
   type Item,
   newItemProps,
@@ -35,6 +36,12 @@ export const handler: Handlers<SignedInState, SignedInState> = {
     const user = await getUserBySession(ctx.state.sessionId);
 
     if (!user) return new Response(null, { status: 400 });
+
+    const items = await getItemsByUser(user.login);
+
+    if (items.some((item) => item.url === url || item.title === title)) {
+      return new Response(null, { status: 400 });
+    }
 
     const item: Item = {
       userLogin: user.login,

--- a/routes/submit/index.tsx
+++ b/routes/submit/index.tsx
@@ -22,25 +22,38 @@ export const handler: Handlers<SignedInState, SignedInState> = {
     const url = form.get("url");
 
     if (typeof title !== "string" || typeof url !== "string") {
-      return new Response("URL or Title are either invalid or missing.", { status: 400 });
+      return new Response("URL or Title are either invalid or missing.", {
+        status: 400,
+      });
     }
 
     try {
       if (!isValidUrl(url) || !isPublicUrl(url)) {
-        return new Response("URL must be valid and publicly available.", { status: 400 });
+        return new Response("URL must be valid and publicly available.", {
+          status: 400,
+        });
       }
     } catch {
-      return new Response("An Error occured while validating the URL.", { status: 500 });
+      return new Response("An Error occurred while validating the URL.", {
+        status: 500,
+      });
     }
 
     const user = await getUserBySession(ctx.state.sessionId);
 
-    if (!user) return new Response("You must be logged in to submit a new Item.", { status: 401 });
+    if (!user) {
+      return new Response("You must be logged in to submit a new Item.", {
+        status: 401,
+      });
+    }
 
     const items = await getItemsByUser(user.login);
 
     if (items.some((item) => item.url === url || item.title === title)) {
-      return new Response("You already submitted an Item which contains the same Title or URL.", { status: 409 });
+      return new Response(
+        "You already submitted an Item which contains the same Title or URL.",
+        { status: 409 },
+      );
     }
 
     const item: Item = {


### PR DESCRIPTION
closes #377.  

this disallows users from submitting duplicate entries.  
upon submission all user entries are checked for uniqueness on either `title` or `url`.