### PR TITLE
refactor: move notifications REST API endpoint

### DIFF
--- a/e2e_test.ts
+++ b/e2e_test.ts
@@ -280,17 +280,21 @@ Deno.test("[http]", async (test) => {
       ...genNewNotification(),
       userLogin: user.login,
     };
-    const req = new Request(
-      `http://localhost/api/users/${user.login}/notifications`,
-    );
+    const url = "http://localhost/api/me/notifications";
 
-    const resp1 = await handler(req);
-    assertResponseNotFound(resp1);
+    const resp1 = await handler(new Request(url));
+    assertFalse(resp1.ok);
+    assertEquals(resp1.body, null);
+    assertEquals(resp1.status, Status.Unauthorized);
 
     await createUser(user);
     await createNotification(notification);
 
-    const resp2 = await handler(req);
+    const resp2 = await handler(
+      new Request(url, {
+        headers: { cookie: "site-session=" + user.sessionId },
+      }),
+    );
     const { values } = await resp2.json();
     assertResponseJson(resp2);
     assertArrayIncludes(values, [

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -14,11 +14,11 @@ import * as $8 from "./routes/api/items/[id]/comments.ts";
 import * as $9 from "./routes/api/items/[id]/index.ts";
 import * as $10 from "./routes/api/items/[id]/vote.ts";
 import * as $11 from "./routes/api/items/index.ts";
-import * as $12 from "./routes/api/me/votes.ts";
-import * as $13 from "./routes/api/stripe-webhooks.ts";
-import * as $14 from "./routes/api/users/[login]/index.ts";
-import * as $15 from "./routes/api/users/[login]/items.ts";
-import * as $16 from "./routes/api/users/[login]/notifications.ts";
+import * as $12 from "./routes/api/me/notifications.ts";
+import * as $13 from "./routes/api/me/votes.ts";
+import * as $14 from "./routes/api/stripe-webhooks.ts";
+import * as $15 from "./routes/api/users/[login]/index.ts";
+import * as $16 from "./routes/api/users/[login]/items.ts";
 import * as $17 from "./routes/api/users/index.ts";
 import * as $18 from "./routes/blog/[slug].tsx";
 import * as $19 from "./routes/blog/index.tsx";
@@ -60,11 +60,11 @@ const manifest = {
     "./routes/api/items/[id]/index.ts": $9,
     "./routes/api/items/[id]/vote.ts": $10,
     "./routes/api/items/index.ts": $11,
-    "./routes/api/me/votes.ts": $12,
-    "./routes/api/stripe-webhooks.ts": $13,
-    "./routes/api/users/[login]/index.ts": $14,
-    "./routes/api/users/[login]/items.ts": $15,
-    "./routes/api/users/[login]/notifications.ts": $16,
+    "./routes/api/me/notifications.ts": $12,
+    "./routes/api/me/votes.ts": $13,
+    "./routes/api/stripe-webhooks.ts": $14,
+    "./routes/api/users/[login]/index.ts": $15,
+    "./routes/api/users/[login]/items.ts": $16,
     "./routes/api/users/index.ts": $17,
     "./routes/blog/[slug].tsx": $18,
     "./routes/blog/index.tsx": $19,

--- a/islands/NotificationsList.tsx
+++ b/islands/NotificationsList.tsx
@@ -23,11 +23,11 @@ function NotificationSummary(props: Notification) {
   );
 }
 
-export default function NotificationsList(props: { userLogin: string }) {
+export default function NotificationsList() {
   const notificationsSig = useSignal<Notification[]>([]);
   const cursorSig = useSignal("");
   const isLoadingSig = useSignal(false);
-  const endpoint = `/api/users/${props.userLogin}/notifications`;
+  const endpoint = `/api/me/notifications`;
 
   async function loadMoreNotifications() {
     isLoadingSig.value = true;

--- a/routes/api/me/notifications.ts
+++ b/routes/api/me/notifications.ts
@@ -1,12 +1,20 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { type Handlers, Status } from "$fresh/server.ts";
-import { collectValues, getUser, listNotificationsByUser } from "@/utils/db.ts";
+import {
+  collectValues,
+  getUserBySession,
+  listNotificationsByUser,
+} from "@/utils/db.ts";
 import { getCursor } from "@/utils/pagination.ts";
+import { State } from "@/routes/_middleware.ts";
 
-/** @todo(iuioiua) Move to GET /api/me/notifications */
-export const handler: Handlers = {
+export const handler: Handlers<undefined, State> = {
   async GET(req, ctx) {
-    const user = await getUser(ctx.params.login);
+    if (ctx.state.sessionId === undefined) {
+      return new Response(null, { status: Status.Unauthorized });
+    }
+
+    const user = await getUserBySession(ctx.state.sessionId);
     if (user === null) return new Response(null, { status: Status.NotFound });
 
     const url = new URL(req.url);

--- a/routes/notifications/index.tsx
+++ b/routes/notifications/index.tsx
@@ -15,7 +15,7 @@ export default async function NotificationsPage(
       <Head title="Notifications" href={ctx.url.href} />
       <main class="flex-1 p-4">
         <h1 class={HEADING_WITH_MARGIN_STYLES}>Notifications</h1>
-        <NotificationsList userLogin={ctx.state.user.login} />
+        <NotificationsList />
       </main>
     </>
   );


### PR DESCRIPTION
From `/api/users/:login/notifications` to `/api/me/notifications`, as the endpoint requires the client to be authenticated.