### PR TITLE
fix: `timeAgo()` usage

### DIFF
--- a/components/UserPostedAt.tsx
+++ b/components/UserPostedAt.tsx
@@ -15,7 +15,7 @@ export default function UserPostedAt(
       <a class="hover:underline" href={`/users/${props.userLogin}`}>
         {props.userLogin}
       </a>{" "}
-      {timeAgo(props.createdAt)} ago
+      {timeAgo(new Date(props.createdAt))} ago
     </p>
   );
 }

--- a/islands/NotificationsList.tsx
+++ b/islands/NotificationsList.tsx
@@ -14,7 +14,7 @@ function NotificationSummary(props: Notification) {
           <strong>New {props.type}!</strong>
         </span>
         <span class="text-gray-500">
-          {" " + timeAgo(props.createdAt)} ago
+          {" " + timeAgo(new Date(props.createdAt))} ago
         </span>
         <br />
         <span>{props.text}</span>


### PR DESCRIPTION
This was preventing feeds from being rendered.