### PR TITLE
refactor: remove submission validations and island utilities

### DIFF
--- a/components/UserPostedAt.tsx
+++ b/components/UserPostedAt.tsx
@@ -15,7 +15,7 @@ export default function UserPostedAt(
       <a class="hover:underline" href={`/users/${props.userLogin}`}>
         {props.userLogin}
       </a>{" "}
-      {timeAgo(new Date(props.createdAt))} ago
+      {timeAgo(new Date(props.createdAt))}
     </p>
   );
 }

--- a/islands/CommentsList.tsx
+++ b/islands/CommentsList.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "preact/hooks";
 import { Comment } from "@/utils/db.ts";
 import UserPostedAt from "@/components/UserPostedAt.tsx";
 import { LINK_STYLES } from "@/utils/constants.ts";
-import { fetchValues } from "@/utils/http.ts";
+import { fetchValues } from "@/utils/islands.ts";
 
 function CommentSummary(props: Comment) {
   return (

--- a/islands/ItemsList.tsx
+++ b/islands/ItemsList.tsx
@@ -5,7 +5,7 @@ import type { Item } from "@/utils/db.ts";
 import { LINK_STYLES } from "@/utils/constants.ts";
 import IconInfo from "tabler_icons_tsx/info-circle.tsx";
 import ItemSummary from "@/components/ItemSummary.tsx";
-import { fetchValues } from "@/utils/http.ts";
+import { fetchValues } from "@/utils/islands.ts";
 
 async function fetchVotedItems() {
   const url = "/api/me/votes";

--- a/islands/NotificationsList.tsx
+++ b/islands/NotificationsList.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "preact/hooks";
 import type { Notification } from "@/utils/db.ts";
 import { LINK_STYLES } from "@/utils/constants.ts";
 import { timeAgo } from "@/utils/display.ts";
-import { fetchValues } from "@/utils/http.ts";
+import { fetchValues } from "@/utils/islands.ts";
 
 function NotificationSummary(props: Notification) {
   return (
@@ -14,7 +14,7 @@ function NotificationSummary(props: Notification) {
           <strong>New {props.type}!</strong>
         </span>
         <span class="text-gray-500">
-          {" " + timeAgo(new Date(props.createdAt))} ago
+          {" " + timeAgo(new Date(props.createdAt))}
         </span>
         <br />
         <span>{props.text}</span>

--- a/islands/UsersTable.tsx
+++ b/islands/UsersTable.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "preact/hooks";
 import type { User } from "@/utils/db.ts";
 import GitHubAvatarImg from "@/components/GitHubAvatarImg.tsx";
 import { LINK_STYLES } from "@/utils/constants.ts";
-import { fetchValues } from "@/utils/http.ts";
+import { fetchValues } from "@/utils/islands.ts";
 
 const TH_STYLES = "p-4 text-left";
 const TD_STYLES = "p-4";

--- a/routes/api/items/[id]/comments.ts
+++ b/routes/api/items/[id]/comments.ts
@@ -1,6 +1,6 @@
 import { Handlers, Status } from "$fresh/server.ts";
 import { collectValues, getItem, listCommentsByItem } from "@/utils/db.ts";
-import { getCursor } from "@/utils/pagination.ts";
+import { getCursor } from "@/utils/http.ts";
 
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export const handler: Handlers = {

--- a/routes/api/items/index.ts
+++ b/routes/api/items/index.ts
@@ -1,6 +1,6 @@
 import { Handlers } from "$fresh/server.ts";
 import { collectValues, listItemsByTime } from "@/utils/db.ts";
-import { getCursor } from "@/utils/pagination.ts";
+import { getCursor } from "@/utils/http.ts";
 
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export const handler: Handlers = {

--- a/routes/api/me/notifications.ts
+++ b/routes/api/me/notifications.ts
@@ -5,7 +5,7 @@ import {
   getUserBySession,
   listNotificationsByUser,
 } from "@/utils/db.ts";
-import { getCursor } from "@/utils/pagination.ts";
+import { getCursor } from "@/utils/http.ts";
 import { State } from "@/routes/_middleware.ts";
 
 export const handler: Handlers<undefined, State> = {

--- a/routes/api/users/[login]/items.ts
+++ b/routes/api/users/[login]/items.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { Handlers, Status } from "$fresh/server.ts";
 import { collectValues, getUser, listItemsByUser } from "@/utils/db.ts";
-import { getCursor } from "@/utils/pagination.ts";
+import { getCursor } from "@/utils/http.ts";
 
 export const handler: Handlers = {
   async GET(req, ctx) {

--- a/routes/api/users/index.ts
+++ b/routes/api/users/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { Handlers } from "$fresh/server.ts";
 import { collectValues, listUsers } from "@/utils/db.ts";
-import { getCursor } from "@/utils/pagination.ts";
+import { getCursor } from "@/utils/http.ts";
 
 export const handler: Handlers = {
   async GET(req) {

--- a/utils/display.ts
+++ b/utils/display.ts
@@ -25,9 +25,9 @@ export function pluralize(amount: number, unit: string) {
  * import { timeAgo } from "@/utils/display.ts";
  * import { SECOND, MINUTE, HOUR } from ""std/datetime/constants.ts""
  *
- * timeAgo(new Date(Date.now() - SECOND)); // Returns "1 second"
- * timeAgo(new Date(Date.now() - 2 * MINUTE)); // Returns "2 minutes"
- * timeAgo(new Date(Date.now() - 3 * HOUR)); // Returns "3 hours"
+ * timeAgo(new Date()); // Returns "just now"
+ * timeAgo(new Date(Date.now() - MINUTE)); // Returns "2 minutes ago"
+ * timeAgo(new Date(Date.now() - 3 * HOUR)); // Returns "3 hours ago"
  * ```
  */
 export function timeAgo(date: Date) {

--- a/utils/display.ts
+++ b/utils/display.ts
@@ -49,8 +49,8 @@ export function timeAgo(date: Date) {
   )
     .toReversed()
     .find(([_, amount]) => amount > 0);
-  if (match === undefined) return "Now";
+  if (match === undefined) return "just now";
   const [unit, amount] = match;
   // Remove the last character which is an "s"
-  return pluralize(amount, unit.slice(0, -1));
+  return pluralize(amount, unit.slice(0, -1)) + " ago";
 }

--- a/utils/display_test.ts
+++ b/utils/display_test.ts
@@ -10,15 +10,18 @@ Deno.test("[display] pluralize()", () => {
 });
 
 Deno.test("[display] timeAgo()", () => {
-  assertEquals(timeAgo(new Date(Date.now())), "Now");
-  assertEquals(timeAgo(new Date(Date.now() - SECOND * 30)), "30 seconds");
-  assertEquals(timeAgo(new Date(Date.now() - MINUTE)), "1 minute");
-  assertEquals(timeAgo(new Date(Date.now() - MINUTE * 2)), "2 minutes");
-  assertEquals(timeAgo(new Date(Date.now() - MINUTE * 59)), "59 minutes");
-  assertEquals(timeAgo(new Date(Date.now() - HOUR)), "1 hour");
-  assertEquals(timeAgo(new Date(Date.now() - HOUR - MINUTE * 35)), "1 hour");
-  assertEquals(timeAgo(new Date(Date.now() - HOUR * 2)), "2 hours");
-  assertEquals(timeAgo(new Date(Date.now() - DAY)), "1 day");
-  assertEquals(timeAgo(new Date(Date.now() - DAY - HOUR * 12)), "1 day");
-  assertEquals(timeAgo(new Date(Date.now() - DAY * 5)), "5 days");
+  assertEquals(timeAgo(new Date(Date.now())), "just now");
+  assertEquals(timeAgo(new Date(Date.now() - SECOND * 30)), "30 seconds ago");
+  assertEquals(timeAgo(new Date(Date.now() - MINUTE)), "1 minute ago");
+  assertEquals(timeAgo(new Date(Date.now() - MINUTE * 2)), "2 minutes ago");
+  assertEquals(timeAgo(new Date(Date.now() - MINUTE * 59)), "59 minutes ago");
+  assertEquals(timeAgo(new Date(Date.now() - HOUR)), "1 hour ago");
+  assertEquals(
+    timeAgo(new Date(Date.now() - HOUR - MINUTE * 35)),
+    "1 hour ago",
+  );
+  assertEquals(timeAgo(new Date(Date.now() - HOUR * 2)), "2 hours ago");
+  assertEquals(timeAgo(new Date(Date.now() - DAY)), "1 day ago");
+  assertEquals(timeAgo(new Date(Date.now() - DAY - HOUR * 12)), "1 day ago");
+  assertEquals(timeAgo(new Date(Date.now() - DAY * 5)), "5 days ago");
 });

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -1,14 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { RedirectStatus, Status } from "std/http/http_status.ts";
 
-export async function fetchValues<T>(endpoint: string, cursor: string) {
-  let url = endpoint;
-  if (cursor !== "") url += "?cursor=" + cursor;
-  const resp = await fetch(url);
-  if (!resp.ok) throw new Error(`Request failed: GET ${url}`);
-  return await resp.json() as { values: T[]; cursor: string };
-}
-
 /**
  * @param location A relative (to the request URL) or absolute URL.
  * @param status HTTP status
@@ -26,30 +18,6 @@ export function redirect(
   });
 }
 
-export function isValidUrl(string: string): boolean {
-  try {
-    const { protocol } = new URL(string);
-    return protocol.startsWith("http");
-  } catch {
-    return false;
-  }
-}
-
-export function isPublicUrl(string: string): boolean {
-  try {
-    const { hostname } = new URL(string);
-    const ranges = [
-      /^localhost$/,
-      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
-      /^::1$/,
-      /^0:0:0:0:0:0:0:1$/,
-      /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
-      /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/,
-      /^192\.168\.\d{1,3}\.\d{1,3}$/,
-    ];
-
-    return !ranges.some((range) => range.test(hostname));
-  } catch (_) {
-    return false;
-  }
+export function getCursor(url: URL) {
+  return url.searchParams.get("cursor") ?? "";
 }

--- a/utils/http_test.ts
+++ b/utils/http_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { isPublicUrl, isValidUrl, redirect } from "./http.ts";
+import { redirect } from "./http.ts";
 import { assert, assertEquals } from "std/testing/asserts.ts";
 
 Deno.test("[http] redirect() defaults", () => {
@@ -21,24 +21,4 @@ Deno.test("[http] redirect()", () => {
   assertEquals(resp.body, null);
   assertEquals(resp.headers.get("location"), location);
   assertEquals(resp.status, status);
-});
-
-Deno.test("[http] isValidUrl()", () => {
-  assertEquals(isValidUrl("https://hunt.deno.land/"), true);
-  assertEquals(isValidUrl("http://hunt.deno.land/"), true);
-  assertEquals(isValidUrl("ws://hunt.deno.land/"), false);
-  assertEquals(isValidUrl("wss://hunt.deno.land/"), false);
-  assertEquals(isValidUrl("invalidurl"), false);
-});
-
-Deno.test("[http] isPublicUrl()", () => {
-  assertEquals(isPublicUrl("https://hunt.deno.land/"), true);
-  assertEquals(isPublicUrl("http://hunt.deno.land/"), true);
-  assertEquals(isPublicUrl("ws://hunt.deno.land/"), true);
-  assertEquals(isPublicUrl("http://localhost/"), false);
-  assertEquals(isPublicUrl("http://127.0.0.1/"), false);
-  assertEquals(isPublicUrl("http://::1/"), false);
-  assertEquals(isPublicUrl("http://10.0.0.0/"), false);
-  assertEquals(isPublicUrl("http://172.16.0.0/"), false);
-  assertEquals(isPublicUrl("http://192.168.0.0/"), false);
 });

--- a/utils/islands.ts
+++ b/utils/islands.ts
@@ -1,0 +1,9 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+
+export async function fetchValues<T>(endpoint: string, cursor: string) {
+  let url = endpoint;
+  if (cursor !== "") url += "?cursor=" + cursor;
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`Request failed: GET ${url}`);
+  return await resp.json() as { values: T[]; cursor: string };
+}

--- a/utils/islands_test.ts
+++ b/utils/islands_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import { getCursor } from "./http.ts";
 import { assertEquals } from "std/testing/asserts.ts";
-import { getCursor } from "./pagination.ts";
 
-Deno.test("[pagaintion] getCursor()", () => {
+Deno.test("[http] getCursor()", () => {
   assertEquals(getCursor(new URL("http://example.com")), "");
   assertEquals(getCursor(new URL("http://example.com?cursor=here")), "here");
 });

--- a/utils/pagination.ts
+++ b/utils/pagination.ts
@@ -1,5 +1,0 @@
-// Copyright 2023 the Deno authors. All rights reserved. MIT license.
-
-export function getCursor(url: URL) {
-  return url.searchParams.get("cursor") ?? "";
-}


### PR DESCRIPTION
As discussed with @mbhrznr, the duplicate submission posted at a different time hits differently. Also, these validations get in the way when locally testing submissions rapidly. This also includes some other minor fixes and cleanups.