### PR TITLE
fix: correct `getCursor()` test location

### DIFF
--- a/utils/http_test.ts
+++ b/utils/http_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { redirect } from "./http.ts";
+import { getCursor, redirect } from "./http.ts";
 import { assert, assertEquals } from "std/testing/asserts.ts";
 
 Deno.test("[http] redirect() defaults", () => {
@@ -21,4 +21,9 @@ Deno.test("[http] redirect()", () => {
   assertEquals(resp.body, null);
   assertEquals(resp.headers.get("location"), location);
   assertEquals(resp.status, status);
+});
+
+Deno.test("[http] getCursor()", () => {
+  assertEquals(getCursor(new URL("http://example.com")), "");
+  assertEquals(getCursor(new URL("http://example.com?cursor=here")), "here");
 });

--- a/utils/islands_test.ts
+++ b/utils/islands_test.ts
@@ -1,8 +1,0 @@
-// Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { getCursor } from "./http.ts";
-import { assertEquals } from "std/testing/asserts.ts";
-
-Deno.test("[http] getCursor()", () => {
-  assertEquals(getCursor(new URL("http://example.com")), "");
-  assertEquals(getCursor(new URL("http://example.com?cursor=here")), "here");
-});


### PR DESCRIPTION
Fixes #481