### PR TITLE
chore: expand test code coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,6 +8,4 @@ coverage:
       default:
         informational: true
 ignore:
-  - "components"
-  - "islands"
-  - "routes"
+  - "**/*.tsx"


### PR DESCRIPTION
This change expands code coverage from ignoring `/routes`, `/components` and `/islands` to ignoring only `.ts` files. This will give us better visibility into what tests to write, especially for REST API endpoints.