### PR TITLE
refactor: cleanup `db:reset` script

### DIFF
--- a/tasks/db_reset.ts
+++ b/tasks/db_reset.ts
@@ -1,21 +1,11 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { kv } from "@/utils/db.ts";
 
-export async function resetKv() {
-  const iter = kv.list({ prefix: [] });
-  const promises = [];
-  for await (const res of iter) promises.push(kv.delete(res.key));
-  await Promise.all(promises);
-}
+if (!confirm("WARNING: The database will be reset. Continue?")) Deno.exit();
 
-if (import.meta.main) {
-  if (
-    !confirm(
-      "This script deletes all data from the Deno KV database. Are you sure you'd like to continue?",
-    )
-  ) {
-    close();
-  }
-  await resetKv();
-  await kv.close();
-}
+const iter = kv.list({ prefix: [] });
+const promises = [];
+for await (const res of iter) promises.push(kv.delete(res.key));
+await Promise.all(promises);
+
+kv.close();


### PR DESCRIPTION
This cleans up some of the unnecessary LOC for the script.

Related to #471