### PR TITLE
chore: add e2e tests for `GET /account/manage` and `GET /account/upgrade`

### DIFF
--- a/e2e_test.ts
+++ b/e2e_test.ts
@@ -82,7 +82,7 @@ Deno.test("[e2e] GET /account/manage", async (test) => {
     assertEquals(resp.status, 303);
   });
 
-  await test.step("returns HTTP 404 Not Found response if user does not have a stripeCustomerId", async () => {
+  await test.step("returns HTTP 404 Not Found response if the session user does not have a Stripe customer ID", async () => {
     const user = genNewUser();
     await createUser({ ...user, stripeCustomerId: undefined });
     const resp = await handler(
@@ -95,7 +95,7 @@ Deno.test("[e2e] GET /account/manage", async (test) => {
     assertEquals(resp.status, Status.NotFound);
   });
 
-  await test.step("returns redirect response to the url returned by stripe after creating a billing portal session", async () => {
+  await test.step("returns redirect response to the URL returned by Stripe after creating a billing portal session", async () => {
     const user = genNewUser();
     await createUser(user);
 
@@ -166,7 +166,7 @@ Deno.test("[e2e] GET /account/upgrade", async (test) => {
     assertEquals(resp.status, Status.NotFound);
   });
 
-  await test.step("returns HTTP 404 Not Found response if stripe returns a null url", async () => {
+  await test.step("returns HTTP 404 Not Found response if Stripe returns a `null` URL", async () => {
     Deno.env.set("STRIPE_PREMIUM_PLAN_PRICE_ID", crypto.randomUUID());
     Deno.env.set("STRIPE_SECRET_KEY", crypto.randomUUID());
 
@@ -190,7 +190,7 @@ Deno.test("[e2e] GET /account/upgrade", async (test) => {
     sessionsCreateStub.restore();
   });
 
-  await test.step("returns redirect response to the url returned by stripe after creating a checkout session", async () => {
+  await test.step("returns redirect response to the URL returned by Stripe after creating a checkout session", async () => {
     const priceId = crypto.randomUUID();
     Deno.env.set("STRIPE_PREMIUM_PLAN_PRICE_ID", priceId);
     Deno.env.set("STRIPE_SECRET_KEY", crypto.randomUUID());

--- a/e2e_test.ts
+++ b/e2e_test.ts
@@ -124,31 +124,6 @@ Deno.test("[e2e] GET /account/manage", async (test) => {
     });
     sessionsCreateStub.restore();
   });
-
-  /* An open question here, should we hit Stripes live API just to test that it fails
-  await test.step("returns an error as the Stripe API fails to authenticate", async () => {
-    const user = genNewUser();
-    await createUser(user);
-
-    const sessionsCreateSpy = spy(stripe.billingPortal.sessions, "create");
-
-    const resp = await handler(
-      new Request(url, {
-        headers: { cookie: "site-session=" + user.sessionId },
-      }),
-    );
-
-    assertFalse(resp.ok);
-    assertEquals(resp.status, Status.InternalServerError);
-    assertSpyCall(sessionsCreateSpy, 0, {
-      args: [{
-        customer: user.stripeCustomerId!,
-        return_url: "http://localhost/account",
-      }],
-    });
-    sessionsCreateSpy.restore();
-  });
-  */
 });
 
 Deno.test("[e2e] GET /account/upgrade", async (test) => {

--- a/e2e_test.ts
+++ b/e2e_test.ts
@@ -135,7 +135,7 @@ Deno.test("[e2e] GET /account/upgrade", async (test) => {
   const user = genNewUser();
   await createUser(user);
 
-  await test.step("returns HTTP 500 Internal Server Error response if stripe premium plan price id is not set", async () => {
+  await test.step("returns HTTP 500 Internal Server Error response if the `STRIPE_PREMIUM_PLAN_PRICE_ID` environment variable is not set", async () => {
     Deno.env.set("STRIPE_SECRET_KEY", crypto.randomUUID());
     Deno.env.delete("STRIPE_PREMIUM_PLAN_PRICE_ID");
     const resp = await handler(
@@ -148,7 +148,7 @@ Deno.test("[e2e] GET /account/upgrade", async (test) => {
     assertEquals(resp.status, Status.InternalServerError);
   });
 
-  await test.step("returns HTTP 404 Not Found response if stripe is not enabled", async () => {
+  await test.step("returns HTTP 404 Not Found response if Stripe is disabled", async () => {
     Deno.env.set("STRIPE_PREMIUM_PLAN_PRICE_ID", crypto.randomUUID());
     Deno.env.delete("STRIPE_SECRET_KEY");
     const resp = await handler(
@@ -222,9 +222,6 @@ Deno.test("[e2e] GET /account/upgrade", async (test) => {
     });
     sessionsCreateStub.restore();
   });
-
-  Deno.env.delete("STRIPE_SECRET_KEY");
-  Deno.env.delete("STRIPE_PREMIUM_PLAN_PRICE_ID");
 });
 
 Deno.test("[e2e] GET /callback", async () => {

--- a/routes/account/manage.ts
+++ b/routes/account/manage.ts
@@ -9,7 +9,7 @@ export default async function AccountManagePage(
   ctx: RouteContext<undefined, SignedInState>,
 ) {
   const { sessionUser } = ctx.state;
-  if (stripe === undefined || sessionUser.stripeCustomerId === undefined) {
+  if (!isStripeEnabled() || sessionUser.stripeCustomerId === undefined) {
     return ctx.renderNotFound();
   }
 

--- a/routes/account/manage.ts
+++ b/routes/account/manage.ts
@@ -1,8 +1,8 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { RouteContext } from "$fresh/server.ts";
-import { stripe } from "@/utils/stripe.ts";
 import type { SignedInState } from "@/middleware/session.ts";
 import { redirect } from "@/utils/http.ts";
+import { isStripeEnabled, stripe } from "@/utils/stripe.ts";
 
 export default async function AccountManagePage(
   _req: Request,

--- a/routes/account/manage.ts
+++ b/routes/account/manage.ts
@@ -3,21 +3,14 @@ import type { RouteContext } from "$fresh/server.ts";
 import { stripe } from "@/utils/stripe.ts";
 import type { SignedInState } from "@/middleware/session.ts";
 import { redirect } from "@/utils/http.ts";
-import { createHttpError } from "std/http/http_errors.ts";
-import { Status } from "std/http/http_status.ts";
 
 export default async function AccountManagePage(
   _req: Request,
   ctx: RouteContext<undefined, SignedInState>,
 ) {
-  if (stripe === undefined) throw createHttpError(Status.NotFound);
-
   const { sessionUser } = ctx.state;
-  if (sessionUser.stripeCustomerId === undefined) {
-    throw createHttpError(
-      Status.NotFound,
-      "User does not have a Stripe customer ID",
-    );
+  if (stripe === undefined || sessionUser.stripeCustomerId === undefined) {
+    return ctx.renderNotFound();
   }
 
   const { url } = await stripe.billingPortal.sessions.create({

--- a/routes/account/upgrade.ts
+++ b/routes/account/upgrade.ts
@@ -1,21 +1,24 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { RouteContext } from "$fresh/server.ts";
-import { isStripeEnabled, stripe } from "@/utils/stripe.ts";
+import {
+  getStripePremiumPlanPriceId,
+  isStripeEnabled,
+  stripe,
+} from "@/utils/stripe.ts";
 import type { SignedInState } from "@/middleware/session.ts";
 import { redirect } from "@/utils/http.ts";
 import { createHttpError } from "std/http/http_errors.ts";
 import { Status } from "std/http/http_status.ts";
 
-const STRIPE_PREMIUM_PLAN_PRICE_ID = Deno.env.get(
-  "STRIPE_PREMIUM_PLAN_PRICE_ID",
-);
-
 export default async function AccountUpgradePage(
   _req: Request,
   ctx: RouteContext<undefined, SignedInState>,
 ) {
-  if (!isStripeEnabled()) throw createHttpError(Status.NotFound);
-  if (STRIPE_PREMIUM_PLAN_PRICE_ID === undefined) {
+  if (!isStripeEnabled()) {
+    return ctx.renderNotFound();
+  }
+  const stripePremiumPlanPriceId = getStripePremiumPlanPriceId();
+  if (stripePremiumPlanPriceId === undefined) {
     throw new Error(
       '"STRIPE_PREMIUM_PLAN_PRICE_ID" environment variable not set',
     );
@@ -26,7 +29,7 @@ export default async function AccountUpgradePage(
     customer: ctx.state.sessionUser.stripeCustomerId,
     line_items: [
       {
-        price: STRIPE_PREMIUM_PLAN_PRICE_ID,
+        price: stripePremiumPlanPriceId,
         quantity: 1,
       },
     ],

--- a/routes/account/upgrade.ts
+++ b/routes/account/upgrade.ts
@@ -1,14 +1,12 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { RouteContext } from "$fresh/server.ts";
+import type { SignedInState } from "@/middleware/session.ts";
+import { redirect } from "@/utils/http.ts";
 import {
   getStripePremiumPlanPriceId,
   isStripeEnabled,
   stripe,
 } from "@/utils/stripe.ts";
-import type { SignedInState } from "@/middleware/session.ts";
-import { redirect } from "@/utils/http.ts";
-import { createHttpError } from "std/http/http_errors.ts";
-import { Status } from "std/http/http_status.ts";
 
 export default async function AccountUpgradePage(
   _req: Request,
@@ -35,7 +33,9 @@ export default async function AccountUpgradePage(
     ],
     mode: "subscription",
   });
-  if (url === null) throw createHttpError(Status.NotFound);
+  if (url === null) {
+    return ctx.renderNotFound();
+  }
 
   return redirect(url);
 }

--- a/routes/account/upgrade.ts
+++ b/routes/account/upgrade.ts
@@ -12,9 +12,7 @@ export default async function AccountUpgradePage(
   _req: Request,
   ctx: RouteContext<undefined, SignedInState>,
 ) {
-  if (!isStripeEnabled()) {
-    return ctx.renderNotFound();
-  }
+  if (!isStripeEnabled()) return ctx.renderNotFound();
   const stripePremiumPlanPriceId = getStripePremiumPlanPriceId();
   if (stripePremiumPlanPriceId === undefined) {
     throw new Error(
@@ -33,9 +31,7 @@ export default async function AccountUpgradePage(
     ],
     mode: "subscription",
   });
-  if (url === null) {
-    return ctx.renderNotFound();
-  }
+  if (url === null) return ctx.renderNotFound();
 
   return redirect(url);
 }

--- a/utils/stripe.ts
+++ b/utils/stripe.ts
@@ -8,6 +8,12 @@ export function isStripeEnabled() {
   return Deno.env.has("STRIPE_SECRET_KEY");
 }
 
+export function getStripePremiumPlanPriceId() {
+  return Deno.env.get(
+    "STRIPE_PREMIUM_PLAN_PRICE_ID",
+  );
+}
+
 export const stripe = new Stripe(STRIPE_SECRET_KEY!, {
   apiVersion: "2023-08-16",
   // Use the Fetch API instead of Node's HTTP client.


### PR DESCRIPTION
First contribution towards improving e2e tests in #524 