### PR TITLE
chore: add e2e tests for `GET /notifications/[id]`

### DIFF
--- a/e2e_test.ts
+++ b/e2e_test.ts
@@ -583,7 +583,7 @@ Deno.test("[e2e] GET /notifications/[id]", async (test) => {
   await createNotification(notification);
   const url = `http://localhost/notifications/${notification.id}`;
 
-  await test.step("returns HTTP 500 Interal Server Error response if the db throws an error while deleting notification key", async () => {
+  await test.step("returns HTTP 500 Internal Server Error response if the db throws an error while deleting notification key", async () => {
     const kvAtomicStub = stub(
       kv,
       "atomic",

--- a/e2e_test.ts
+++ b/e2e_test.ts
@@ -557,9 +557,9 @@ Deno.test("[e2e] GET /notifications/[id]", async (test) => {
   await test.step("returns redirect response if the session user is not signed in", async () => {
     const resp = await handler(new Request(notificationNotFoundUrl));
     assertFalse(resp.ok);
-    assertFalse(resp.body);
+    assertEquals(resp.body, null);
     assertEquals(resp.headers.get("location"), "/signin");
-    assertEquals(resp.status, 303);
+    assertEquals(resp.status, Status.SeeOther);
   });
 
   const user = genNewUser();
@@ -599,7 +599,7 @@ Deno.test("[e2e] GET /notifications/[id]", async (test) => {
       }),
     );
 
-    assertEquals(resp.status, 500);
+    assertEquals(resp.status, Status.InternalServerError);
     kvAtomicStub.restore();
   });
 
@@ -610,7 +610,7 @@ Deno.test("[e2e] GET /notifications/[id]", async (test) => {
       }),
     );
     assertEquals(resp.headers.get("location"), notification.originUrl);
-    assertEquals(resp.status, 303);
+    assertEquals(resp.status, Status.SeeOther);
   });
 
   await test.step("returns HTTP 404 Not Found response after the notification was visited and the key was deleted", async () => {

--- a/routes/notifications/[id].ts
+++ b/routes/notifications/[id].ts
@@ -8,9 +8,14 @@ export default async function NotificationPage(
   _req: Request,
   ctx: RouteContext<undefined, SignedInState>,
 ) {
-  const notification = await getAndDeleteNotification({
-    id: ctx.params.id,
-    userLogin: ctx.state.sessionUser.login,
-  });
-  return redirect(notification.originUrl);
+  try {
+    const notification = await getAndDeleteNotification({
+      id: ctx.params.id,
+      userLogin: ctx.state.sessionUser.login,
+    });
+    return redirect(notification.originUrl);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return ctx.renderNotFound();
+    throw error;
+  }
 }


### PR DESCRIPTION
Adds coverage as part of #524 

The page can throw a general error, which would happen if the notification was found but then deleting the key in KV failed. I can't think of a great way to exercise this code path unless we mock `getAndDeleteNotification` for one test and have it throw?