### PR TITLE
feat: `deno task cov:view`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: deno task ok
 
       - name: Create lcov file
-        run: deno task cov
+        run: deno task cov:gen
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cov.lcov
 .idea
 _fresh/
 backup.json
+html_cov/

--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,8 @@
     "check:license": "deno run --allow-read --allow-write tasks/check_license.ts",
     "check:types": "deno check **/*.ts && deno check **/*.tsx",
     "ok": "deno fmt --check && deno lint && deno task check:license --check && deno task check:types && deno task test",
-    "cov": "deno coverage ./cov/ --lcov --exclude='test.ts' > cov.lcov",
+    "cov:gen": "deno coverage ./cov/ --lcov --exclude='test.ts' > cov.lcov",
+    "cov:view": "genhtml -o html_cov cov.lcov && open html_cov/index.html",
     "update": "deno run -A -r https://fresh.deno.dev/update .",
     "build": "deno run -A --unstable dev.ts build",
     "preview": "deno run -A --unstable main.ts"


### PR DESCRIPTION
The `cov:view` task generates HTML to view LCOV files using [`genhtml`](https://linux.die.net/man/1/genhtml) and then opens the main page in the local machine's browser. This is good for analysing test coverage locally. The `cov` task has also been renamed to `cov:gen`.