### PR TITLE
fix: avoid showing "No items found" stats in `<ItemsList />`

### DIFF
--- a/islands/ItemsList.tsx
+++ b/islands/ItemsList.tsx
@@ -75,22 +75,24 @@ export default function ItemsList(
       .finally(() => loadMoreItems());
   }, []);
 
+  if (isLoadingSig.value === undefined || isLoadingSig.value === true) {
+    return <>█</>;
+  }
+
   return (
     <div>
-      {isLoadingSig.value !== undefined && !isLoadingSig.value
-        ? itemsSig.value.length > 0
-          ? itemsSig.value.map((item, id) => {
-            return (
-              <ItemSummary
-                key={item.id}
-                item={item}
-                isVoted={itemsAreVotedSig.value[id]}
-                isSignedIn={props.isSignedIn}
-              />
-            );
-          })
-          : <EmptyItemsList />
-        : "█"}
+      {itemsSig.value.length > 0
+        ? itemsSig.value.map((item, id) => {
+          return (
+            <ItemSummary
+              key={item.id}
+              item={item}
+              isVoted={itemsAreVotedSig.value[id]}
+              isSignedIn={props.isSignedIn}
+            />
+          );
+        })
+        : <EmptyItemsList />}
       {cursorSig.value !== "" && (
         <button onClick={loadMoreItems} class={LINK_STYLES}>
           {isLoadingSig.value ? "Loading..." : "Load more"}

--- a/islands/ItemsList.tsx
+++ b/islands/ItemsList.tsx
@@ -81,7 +81,7 @@ export default function ItemsList(
 
   return (
     <div>
-      {itemsSig.value.length > 0
+      {itemsSig.value.length
         ? itemsSig.value.map((item, id) => {
           return (
             <ItemSummary

--- a/islands/ItemsList.tsx
+++ b/islands/ItemsList.tsx
@@ -75,8 +75,8 @@ export default function ItemsList(
       .finally(() => loadMoreItems());
   }, []);
 
-  if (isLoadingSig.value === undefined || isLoadingSig.value === true) {
-    return <>█</>;
+  if (isLoadingSig.value === undefined) {
+    return <>Loading...</>;
   }
 
   return (

--- a/islands/ItemsList.tsx
+++ b/islands/ItemsList.tsx
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { useComputed, useSignal } from "@preact/signals";
 import { useEffect } from "preact/hooks";
-import type { Item, User } from "@/utils/db.ts";
+import { type Item } from "@/utils/db.ts";
 import { LINK_STYLES } from "@/utils/constants.ts";
 import IconInfo from "tabler_icons_tsx/info-circle.tsx";
 import ItemSummary from "@/components/ItemSummary.tsx";
@@ -40,7 +40,7 @@ export default function ItemsList(
   const itemsSig = useSignal<Item[]>([]);
   const votedItemsIdsSig = useSignal<string[]>([]);
   const cursorSig = useSignal("");
-  const isLoadingSig = useSignal(false);
+  const isLoadingSig = useSignal<boolean | undefined>(undefined);
   const itemsAreVotedSig = useComputed(() =>
     itemsSig.value.map((item) => votedItemsIdsSig.value.includes(item.id))
   );
@@ -77,18 +77,20 @@ export default function ItemsList(
 
   return (
     <div>
-      {itemsSig.value.length
-        ? itemsSig.value.map((item, id) => {
-          return (
-            <ItemSummary
-              key={item.id}
-              item={item}
-              isVoted={itemsAreVotedSig.value[id]}
-              isSignedIn={props.isSignedIn}
-            />
-          );
-        })
-        : <EmptyItemsList />}
+      {isLoadingSig.value !== undefined && !isLoadingSig.value
+        ? itemsSig.value.length > 0
+          ? itemsSig.value.map((item, id) => {
+            return (
+              <ItemSummary
+                key={item.id}
+                item={item}
+                isVoted={itemsAreVotedSig.value[id]}
+                isSignedIn={props.isSignedIn}
+              />
+            );
+          })
+          : <EmptyItemsList />
+        : "█"}
       {cursorSig.value !== "" && (
         <button onClick={loadMoreItems} class={LINK_STYLES}>
           {isLoadingSig.value ? "Loading..." : "Load more"}

--- a/islands/ItemsList.tsx
+++ b/islands/ItemsList.tsx
@@ -76,7 +76,7 @@ export default function ItemsList(
   }, []);
 
   if (isLoadingSig.value === undefined) {
-    return <>Loading...</>;
+    return <p class={LINK_STYLES}>Loading...</p>;
   }
 
   return (


### PR DESCRIPTION
fixes #472 

@iuioiua this is as simple as I got, without being too intrusive; I personally like it; the problem was a bug regarding the state change of the variable `isLoadingSig`, I was able to avoid it by initializing the variable as `undefined` and bypassing it with the conditional rendering not sure if is worth taking another look at it some other time.

Note: The simplicity of this PR does not reflect at all the time that took me to get there — just for the record.