### PR TITLE
fix: prevent homepage from crashing

### DIFF
--- a/islands/ItemsList.tsx
+++ b/islands/ItemsList.tsx
@@ -103,6 +103,15 @@ interface ItemSummaryProps {
 }
 
 function ItemSummary(props: ItemSummaryProps) {
+  let createdTimeAgo: string;
+
+  try {
+    createdTimeAgo = timeAgo(new Date(decodeTime(props.item.id)));
+  } catch (err) {
+    // @ts-ignore old items, which still have a `uuid`, also have a `createdAt` property
+    createdTimeAgo = timeAgo(new Date(props.item?.createdAt));
+  }
+
   return (
     <div class="py-2 flex gap-4">
       {props.isSignedIn
@@ -138,7 +147,7 @@ function ItemSummary(props: ItemSummaryProps) {
           <a class="hover:underline" href={`/users/${props.item.userLogin}`}>
             {props.item.userLogin}
           </a>{" "}
-          {timeAgo(new Date(decodeTime(props.item.id)))}
+          {createdTimeAgo}
         </p>
       </div>
     </div>


### PR DESCRIPTION
currently https://hunt.deno.land/ crashes with the following error in the console:

<img width="1386" alt="Bildschirm­foto 2023-09-13 um 00 17 44" src="https://github.com/denoland/saaskit/assets/8133892/f37793b1-baab-4ac7-a2c2-3733530886a3">

this seems to happen whenever any of the items still uses the old data model w/ `uuid` and `createdAt`, rather than `ulid`.
this pr adds a quick and naive `try/catch` block to prevent the page items list from crashing.

however the underlying issue should be handled via a db migration on prod's database.