### PR TITLE
chore: cleanup `createdTimeAgo` logic

### DIFF
--- a/islands/ItemsList.tsx
+++ b/islands/ItemsList.tsx
@@ -103,15 +103,6 @@ interface ItemSummaryProps {
 }
 
 function ItemSummary(props: ItemSummaryProps) {
-  let createdTimeAgo: string;
-
-  try {
-    createdTimeAgo = timeAgo(new Date(decodeTime(props.item.id)));
-  } catch (err) {
-    // @ts-ignore old items, which still have a `uuid`, also have a `createdAt` property
-    createdTimeAgo = timeAgo(new Date(props.item?.createdAt));
-  }
-
   return (
     <div class="py-2 flex gap-4">
       {props.isSignedIn
@@ -147,7 +138,7 @@ function ItemSummary(props: ItemSummaryProps) {
           <a class="hover:underline" href={`/users/${props.item.userLogin}`}>
             {props.item.userLogin}
           </a>{" "}
-          {createdTimeAgo}
+          {timeAgo(new Date(decodeTime(props.item.id)))}
         </p>
       </div>
     </div>


### PR DESCRIPTION
A recent database migration means this logic is no longer needed.