### PR TITLE
refactor: rework submit logic and errors

### DIFF
--- a/e2e_test.ts
+++ b/e2e_test.ts
@@ -228,20 +228,12 @@ Deno.test("[e2e] GET /api/items", async () => {
   assertArrayIncludes(values, [item1, item2]);
 });
 
-Deno.test("[e2e] POST /api/items", async (test) => {
-  const url = "http://localhost/api/items";
+Deno.test("[e2e] POST /submit", async (test) => {
+  const url = "http://localhost/submit";
   const user = randomUser();
   await createUser(user);
 
-  await test.step("serves unauthorized response if the session user is not signed in", async () => {
-    const resp = await handler(new Request(url, { method: "POST" }));
-
-    assertEquals(resp.status, Status.Unauthorized);
-    assertText(resp);
-    assertEquals(await resp.text(), "User must be signed in");
-  });
-
-  await test.step("serves bad request response if item is missing title", async () => {
+  await test.step("redirects to `/submit?error` if item is missing title", async () => {
     const body = new FormData();
     const resp = await handler(
       new Request(url, {
@@ -251,12 +243,10 @@ Deno.test("[e2e] POST /api/items", async (test) => {
       }),
     );
 
-    assertEquals(resp.status, Status.BadRequest);
-    assertText(resp);
-    assertEquals(await resp.text(), "Title is missing");
+    assertRedirect(resp, "/submit?error");
   });
 
-  await test.step("serves bad request response if item is missing URL", async () => {
+  await test.step("redirects to `/submit?error` if item is missing URL", async () => {
     const body = new FormData();
     body.set("title", "Title text");
     const resp = await handler(
@@ -267,12 +257,10 @@ Deno.test("[e2e] POST /api/items", async (test) => {
       }),
     );
 
-    assertEquals(resp.status, Status.BadRequest);
-    assertText(resp);
-    assertEquals(await resp.text(), "URL is invalid or missing");
+    assertRedirect(resp, "/submit?error");
   });
 
-  await test.step("serves bad request response if item has an invalid URL", async () => {
+  await test.step("redirects to `/submit?error` if item has an invalid URL", async () => {
     const body = new FormData();
     body.set("title", "Title text");
     body.set("url", "invalid-url");
@@ -284,9 +272,7 @@ Deno.test("[e2e] POST /api/items", async (test) => {
       }),
     );
 
-    assertEquals(resp.status, Status.BadRequest);
-    assertText(resp);
-    assertEquals(await resp.text(), "URL is invalid or missing");
+    assertRedirect(resp, "/submit?error");
   });
 
   await test.step("creates an item and redirects to the home page", async () => {

--- a/routes/api/items/index.ts
+++ b/routes/api/items/index.ts
@@ -1,15 +1,10 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+
 import { collectValues, listItems } from "@/utils/db.ts";
 import { getCursor } from "@/utils/http.ts";
-import { type Handlers } from "$fresh/server.ts";
-import { createItem, type Item } from "@/utils/db.ts";
-import { redirect } from "@/utils/http.ts";
-import { assertSignedIn, State } from "@/plugins/session.ts";
-import { createHttpError } from "std/http/http_errors.ts";
-import { ulid } from "std/ulid/mod.ts";
-import { Status } from "std/http/http_status.ts";
+import type { Handlers } from "$fresh/server.ts";
 
-// Copyright 2023 the Deno authors. All rights reserved. MIT license.
-export const handler: Handlers<undefined, State> = {
+export const handler: Handlers = {
   async GET(req) {
     const url = new URL(req.url);
     const iter = listItems({
@@ -19,29 +14,5 @@ export const handler: Handlers<undefined, State> = {
     });
     const values = await collectValues(iter);
     return Response.json({ values, cursor: iter.cursor });
-  },
-  async POST(req, ctx) {
-    assertSignedIn(ctx);
-
-    const form = await req.formData();
-    const title = form.get("title");
-    const url = form.get("url");
-
-    if (typeof title !== "string") {
-      throw createHttpError(Status.BadRequest, "Title is missing");
-    }
-    if (typeof url !== "string" || !URL.canParse(url)) {
-      throw createHttpError(Status.BadRequest, "URL is invalid or missing");
-    }
-
-    const item: Item = {
-      id: ulid(),
-      userLogin: ctx.state.sessionUser.login,
-      title,
-      url,
-      score: 0,
-    };
-    await createItem(item);
-    return redirect("/");
   },
 };


### PR DESCRIPTION
This change moves the logic for `POST /api/items` to the more appropriate `POST /submit` and adds a simple error message if the form was submitted incorrectly.