### PR TITLE
refactor: use `DENO_KV_PATH` environment variable

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "db:migrate": "deno run --allow-read --allow-env --allow-net --unstable tasks/db_migrate.ts",
     "db:reset": "deno run --allow-read --allow-env --unstable tasks/db_reset.ts",
     "start": "deno run --unstable -A --watch=static/,routes/ dev.ts",
-    "test": "KV_PATH=:memory: deno test -A --unstable --parallel --coverage=./cov --doc",
+    "test": "DENO_KV_PATH=:memory: deno test -A --unstable --parallel --coverage=./cov --doc",
     "check:license": "deno run --allow-read --allow-write tasks/check_license.ts",
     "check:types": "deno check **/*.ts && deno check **/*.tsx",
     "ok": "deno fmt --check && deno lint && deno task check:license --check && deno task check:types && deno task test",

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1,13 +1,13 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { ulid } from "std/ulid/mod.ts";
 
-const KV_PATH_KEY = "KV_PATH";
+const DENO_KV_PATH_KEY = "DENO_KV_PATH";
 let path = undefined;
 if (
-  (await Deno.permissions.query({ name: "env", variable: KV_PATH_KEY }))
+  (await Deno.permissions.query({ name: "env", variable: DENO_KV_PATH_KEY }))
     .state === "granted"
 ) {
-  path = Deno.env.get(KV_PATH_KEY);
+  path = Deno.env.get(DENO_KV_PATH_KEY);
 }
 export const kv = await Deno.openKv(path);
 


### PR DESCRIPTION
This aligns with Deno Deploy's `DENO_KV_ACCESS_TOKEN` environment variable.