### PR TITLE
fix: premium state in users table

### DIFF
--- a/islands/UsersTable.tsx
+++ b/islands/UsersTable.tsx
@@ -26,8 +26,7 @@ function UserTableRow(props: User) {
         {props.isSubscribed
           ? (
             <>
-              "Premium "
-              <PremiumBadge class="w-5 h-5 inline" />
+              Premium <PremiumBadge class="w-5 h-5 inline" />
             </>
           )
           : "Basic"}


### PR DESCRIPTION
Before:
![hunt deno land_dashboard_users](https://github.com/denoland/saaskit/assets/29347852/6a7a46fc-0430-480c-a0dd-757d2b2ae337)

After:
![localhost_8000_dashboard_users (3)](https://github.com/denoland/saaskit/assets/29347852/b703a658-b692-463f-9d42-489c635b91f3)
