### PR TITLE
refactor: minor `<EmptyItemsList />` tweaks

### DIFF
--- a/islands/ItemsList.tsx
+++ b/islands/ItemsList.tsx
@@ -18,21 +18,13 @@ async function fetchVotedItems() {
 
 function EmptyItemsList() {
   return (
-    <>
-      <div class="flex flex-col justify-center items-center gap-2">
-        <div class="flex flex-col items-center gap-2 pt-16">
-          <IconInfo class="w-10 h-10 text-gray-400 dark:text-gray-600" />
-          <p class="text-center font-medium">No items found</p>
-        </div>
-
-        <a
-          href="/submit"
-          class="inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-primary hover:underline"
-        >
-          Submit your project
-        </a>
-      </div>
-    </>
+    <div class="flex flex-col justify-center items-center gap-2 pt-16">
+      <IconInfo class="w-10 h-10 text-gray-400 dark:text-gray-600" />
+      <p>No items found</p>
+      <a href="/submit" class="text-primary hover:underline">
+        Submit your project &#8250;
+      </a>
+    </div>
   );
 }
 

--- a/routes/_404.tsx
+++ b/routes/_404.tsx
@@ -6,7 +6,7 @@ export default function NotFoundPage() {
     <main class="flex-1 p-4 flex flex-col justify-center text-center">
       <h1 class={HEADING_STYLES}>Page not found</h1>
       <p>
-        <a href="/" class={LINK_STYLES}>Return home ›</a>
+        <a href="/" class={LINK_STYLES}>Return home &#8250;</a>
       </p>
     </main>
   );

--- a/routes/_500.tsx
+++ b/routes/_500.tsx
@@ -8,7 +8,7 @@ export default function Error500Page(props: ErrorPageProps) {
       <h1 class={HEADING_STYLES}>Server error</h1>
       <p>500 internal error: {(props.error as Error).message}</p>
       <p>
-        <a href="/" class={LINK_STYLES}>Return home ›</a>
+        <a href="/" class={LINK_STYLES}>Return home &#8250;</a>
       </p>
     </main>
   );

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -22,7 +22,7 @@ function SetupInstruction() {
           href="https://github.com/denoland/saaskit#auth-oauth"
           class="inline-flex gap-2 text-green-600 dark:text-green-400 hover:underline cursor-pointer"
         >
-          See the guide ›
+          See the guide &#8250;
         </a>
       </p>
 


### PR DESCRIPTION
It's now a little simpler and the `›` symbol is replaced with the HTML encoded string.