### PR TITLE
docs: fix Discord link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ apply, such as:
 ## Community and Resources
 
 Join
-[the `#saaskit` channel in Deno's Discord](https://discord.com/channels/684898665143206084/1085986084653109438)
+[the `#saaskit` channel in Deno's Discord](https://discord.gg/deno)
 to meet other SaaSKit developers, ask questions, and get unblocked.
 
 Here's a list of articles, how to guides, and videos about SaaSKit:

--- a/README.md
+++ b/README.md
@@ -460,9 +460,8 @@ apply, such as:
 
 ## Community and Resources
 
-Join
-[the `#saaskit` channel in Deno's Discord](https://discord.gg/deno)
-to meet other SaaSKit developers, ask questions, and get unblocked.
+Join [the `#saaskit` channel in Deno's Discord](https://discord.gg/deno) to meet
+other SaaSKit developers, ask questions, and get unblocked.
 
 Here's a list of articles, how to guides, and videos about SaaSKit:
 


### PR DESCRIPTION
In this PR, I have fixed the broken link of discord in the README.
Now it redirects to the correct link of the Discord Server of Deno.

This PR fixes #636 