### PR TITLE
refactor: remove use of `std/http/http_errors`

### DIFF
--- a/fresh.config.ts
+++ b/fresh.config.ts
@@ -6,7 +6,7 @@ import sessionPlugin from "./plugins/session.ts";
 import errorHandling from "./plugins/error_handling.ts";
 import securityHeaders from "./plugins/security_headers.ts";
 import welcomePlugin from "./plugins/welcome.ts";
-import { FreshOptions } from "$fresh/server.ts";
+import type { FreshConfig } from "$fresh/server.ts";
 
 export default {
   plugins: [
@@ -17,4 +17,4 @@ export default {
     errorHandling,
     securityHeaders,
   ],
-} as FreshOptions;
+} as FreshConfig;

--- a/plugins/session.ts
+++ b/plugins/session.ts
@@ -4,8 +4,7 @@ import type { MiddlewareHandlerContext } from "$fresh/server.ts";
 import { getSessionId } from "kv_oauth/mod.ts";
 import { getUserBySession } from "@/utils/db.ts";
 import type { User } from "@/utils/db.ts";
-import { createHttpError } from "std/http/http_errors.ts";
-import { Status } from "std/http/http_status.ts";
+import { UnauthorizedError } from "@/utils/http.ts";
 
 export interface State {
   sessionUser?: User;
@@ -17,7 +16,7 @@ export function assertSignedIn(
   ctx: { state: State },
 ): asserts ctx is { state: SignedInState } {
   if (ctx.state.sessionUser === undefined) {
-    throw createHttpError(Status.Unauthorized, "User must be signed in");
+    throw new UnauthorizedError("User must be signed in");
   }
 }
 

--- a/routes/api/items/[id].ts
+++ b/routes/api/items/[id].ts
@@ -1,13 +1,11 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import type { Handlers } from "$fresh/server.ts";
 import { getItem } from "@/utils/db.ts";
-import { Status } from "std/http/http_status.ts";
-import { createHttpError } from "std/http/http_errors.ts";
 
 export const handler: Handlers = {
   async GET(_req, ctx) {
     const item = await getItem(ctx.params.id);
-    if (item === null) throw createHttpError(Status.NotFound, "Item not found");
+    if (item === null) throw new Deno.errors.NotFound("Item not found");
     return Response.json(item);
   },
 };

--- a/routes/api/users/[login]/index.ts
+++ b/routes/api/users/[login]/index.ts
@@ -1,12 +1,11 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { type Handlers, Status } from "$fresh/server.ts";
+import type { Handlers } from "$fresh/server.ts";
 import { getUser } from "@/utils/db.ts";
-import { createHttpError } from "std/http/http_errors.ts";
 
 export const handler: Handlers = {
   async GET(_req, ctx) {
     const user = await getUser(ctx.params.login);
-    if (user === null) throw createHttpError(Status.NotFound, "User not found");
+    if (user === null) throw new Deno.errors.NotFound("User not found");
     return Response.json(user);
   },
 };

--- a/routes/api/users/[login]/items.ts
+++ b/routes/api/users/[login]/items.ts
@@ -2,13 +2,11 @@
 import type { Handlers } from "$fresh/server.ts";
 import { collectValues, getUser, listItemsByUser } from "@/utils/db.ts";
 import { getCursor } from "@/utils/http.ts";
-import { Status } from "std/http/http_status.ts";
-import { createHttpError } from "std/http/http_errors.ts";
 
 export const handler: Handlers = {
   async GET(req, ctx) {
     const user = await getUser(ctx.params.login);
-    if (user === null) throw createHttpError(Status.NotFound, "User not found");
+    if (user === null) throw new Deno.errors.NotFound("User not found");
 
     const url = new URL(req.url);
     const iter = listItemsByUser(ctx.params.login, {

--- a/routes/api/vote.ts
+++ b/routes/api/vote.ts
@@ -2,16 +2,13 @@
 import { type Handlers, Status } from "$fresh/server.ts";
 import type { SignedInState } from "@/plugins/session.ts";
 import { createVote } from "@/utils/db.ts";
-import { createHttpError } from "std/http/http_errors.ts";
+import { BadRequestError } from "@/utils/http.ts";
 
 export const handler: Handlers<undefined, SignedInState> = {
   async POST(req, ctx) {
     const itemId = new URL(req.url).searchParams.get("item_id");
     if (itemId === null) {
-      throw createHttpError(
-        Status.BadRequest,
-        "`item_id` URL parameter missing",
-      );
+      throw new BadRequestError("`item_id` URL parameter missing");
     }
 
     await createVote({

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { createHttpError } from "std/http/http_errors.ts";
 import { createGitHubOAuthConfig } from "kv_oauth/mod.ts";
+import { BadRequestError } from "@/utils/http.ts";
 
 export function isGitHubSetup() {
   try {
@@ -37,7 +37,7 @@ export async function getGitHubUser(accessToken: string) {
   });
   if (!resp.ok) {
     const { message } = await resp.json();
-    throw createHttpError(resp.status, message);
+    throw new BadRequestError(message);
   }
   return await resp.json() as Promise<GitHubUser>;
 }

--- a/utils/github_test.ts
+++ b/utils/github_test.ts
@@ -2,9 +2,9 @@
 import { assertRejects } from "std/assert/assert_rejects.ts";
 import { getGitHubUser } from "./github.ts";
 import { returnsNext, stub } from "std/testing/mock.ts";
-import { errors } from "std/http/http_errors.ts";
 import { assertEquals } from "std/assert/assert_equals.ts";
 import { Status } from "kv_oauth/deps.ts";
+import { BadRequestError } from "@/utils/http.ts";
 
 Deno.test("[plugins] getGitHubUser()", async (test) => {
   await test.step("rejects on error message", async () => {
@@ -20,7 +20,7 @@ Deno.test("[plugins] getGitHubUser()", async (test) => {
     );
     await assertRejects(
       async () => await getGitHubUser(crypto.randomUUID()),
-      errors.BadRequest,
+      BadRequestError,
       message,
     );
     fetchStub.restore();

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -67,3 +67,17 @@ export async function fetchValues<T>(endpoint: string, cursor: string) {
   if (!resp.ok) throw new Error(`Request failed: GET ${url}`);
   return await resp.json() as { values: T[]; cursor: string };
 }
+
+export class UnauthorizedError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class BadRequestError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "BadRequestError";
+  }
+}


### PR DESCRIPTION
It appears `std/http/http_errors` will be getting removed (see [here](https://github.com/denoland/deno_std/pull/3736)). Removing this dependency actually makes things cleaner.