### PR TITLE
refactor: use `Array.fromAsync()`

### DIFF
--- a/tasks/db_dump.ts
+++ b/tasks/db_dump.ts
@@ -15,9 +15,10 @@ function replacer(_key: unknown, value: unknown) {
   return typeof value === "bigint" ? value.toString() : value;
 }
 
-const iter = kv.list({ prefix: [] });
-const items = [];
-for await (const { key, value } of iter) items.push({ key, value });
+const items = await Array.fromAsync(
+  kv.list({ prefix: [] }),
+  ({ key, value }) => ({ key, value }),
+);
 console.log(JSON.stringify(items, replacer, 2));
 
 kv.close();

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -28,9 +28,7 @@ export const kv = await Deno.openKv(path);
  * ```
  */
 export async function collectValues<T>(iter: Deno.KvListIterator<T>) {
-  const values = [];
-  for await (const { value } of iter) values.push(value);
-  return values;
+  return await Array.fromAsync(iter, ({ value }) => value);
 }
 
 // Item

--- a/utils/posts.ts
+++ b/utils/posts.ts
@@ -68,13 +68,11 @@ export async function getPost(slug: string): Promise<Post | null> {
  * ```
  */
 export async function getPosts(): Promise<Post[]> {
-  const files = Deno.readDir("./posts");
-  const promises = [];
-  for await (const file of files) {
-    const slug = file.name.replace(".md", "");
-    promises.push(getPost(slug));
-  }
-  const posts = await Promise.all(promises) as Post[];
-  posts.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
-  return posts;
+  const posts = await Array.fromAsync(
+    Deno.readDir("./posts"),
+    async (file) => await getPost(file.name.replace(".md", "")),
+  ) as Post[];
+  return posts.toSorted((a, b) =>
+    b.publishedAt.getTime() - a.publishedAt.getTime()
+  );
 }


### PR DESCRIPTION
[Deno 1.38](https://deno.com/blog/v1.38#v8-120) now supports [`Array.fromAsync()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync).