### PR TITLE
bug: load .env for init:stripe task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "tasks": {
-    "init:stripe": "deno run --allow-read --allow-env --allow-net tasks/init_stripe.ts",
+    "init:stripe": "deno run --allow-read --allow-env --allow-net --env tasks/init_stripe.ts",
     "db:dump": "deno run --allow-read --allow-env --unstable tasks/db_dump.ts",
     "db:restore": "deno run --allow-read --allow-env --unstable tasks/db_restore.ts",
     "db:seed": "deno run --allow-read --allow-env --allow-net --unstable tasks/db_seed.ts",


### PR DESCRIPTION
As per #648 

**Expected behavior** 
`init_stripe` script runs using the `STRIPE_SECRET_KEY` key defined in `.env` and successfully returns the `STRIPE_PREMIUM_PLAN_PRICE_ID` to stdout, as defined in the README.md

In this PR I have loaded the `.env` via the `--env` flag in the init:stripe task to match the desired behaviour oulined in the README.md