### PR TITLE
chore: improve atomicity of E2E tests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "db:migrate": "deno run --allow-read --allow-env --allow-net --unstable tasks/db_migrate.ts",
     "db:reset": "deno run --allow-read --allow-env --unstable tasks/db_reset.ts",
     "start": "deno run --unstable -A --watch=static/,routes/ --env dev.ts",
-    "test": "DENO_KV_PATH=:memory: GITHUB_CLIENT_ID=xxx GITHUB_CLIENT_SECRET=xxx deno test -A --unstable --parallel --coverage",
+    "test": "DENO_KV_PATH=:memory: deno test -A --unstable --coverage",
     "check:license": "deno run --allow-read --allow-write tasks/check_license.ts",
     "check:types": "deno check **/*.ts && deno check **/*.tsx",
     "ok": "deno fmt --check && deno lint && deno task check:license --check && deno task check:types && deno task test",

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "db:migrate": "deno run --allow-read --allow-env --allow-net --unstable tasks/db_migrate.ts",
     "db:reset": "deno run --allow-read --allow-env --unstable tasks/db_reset.ts",
     "start": "deno run --unstable -A --watch=static/,routes/ --env dev.ts",
-    "test": "DENO_KV_PATH=:memory: deno test -A --unstable --coverage",
+    "test": "DENO_KV_PATH=:memory: deno test -A --parallel --unstable --coverage",
     "check:license": "deno run --allow-read --allow-write tasks/check_license.ts",
     "check:types": "deno check **/*.ts && deno check **/*.tsx",
     "ok": "deno fmt --check && deno lint && deno task check:license --check && deno task check:types && deno task test",


### PR DESCRIPTION
### Issue
The e2e test runner was setting ENV from multiple sources leading cognitive complexity when reading, writing, and running tests. In particular, Github vars were passed as part of `deno task test` while STRIPE entities were not. 

### Observations

1. Tests had different outcomes if run outside of the deno.json `test` task.
2. Tests were not atomically runnable as they were unaware of their required ENV vars. 
3. A users ENV could alter the outcome of tests

### Improvement
I created a `setupEnv` function which defines the base ENV state our application expects and provides a mechanism for mutating it into what a given test requires.

1. All tests start with the same base 
2. Tests are atomic
3. Deno task args minimally impact test outcomes (👀 `DENO_KV_PATH`)
6. User ENV minimally impacts test outcomes


### Example Behaviours

#### Pass a computed value as the input for an Environment Variable
```javascript
    const priceId = crypto.randomUUID();
    setupEnv(
      { "STRIPE_PREMIUM_PLAN_PRICE_ID": priceId },
    );
```

#### Ensure an Environment Variable is unset 

```javascript
    setupEnv(
      { "STRIPE_SECRET_KEY": null },
    );
```