### PR TITLE
chore: allow license check to be multiline

### DIFF
--- a/tasks/check_license.ts
+++ b/tasks/check_license.ts
@@ -14,7 +14,8 @@ const ROOT = new URL("../", import.meta.url);
 const CHECK = Deno.args.includes("--check");
 const CURRENT_YEAR = new Date().getFullYear();
 const RX_COPYRIGHT = new RegExp(
-  `// Copyright 2023-([0-9]{4}) the Deno authors\\. All rights reserved\\. MIT license\\.\n`,
+  `// Copyright 2023-([0-9]{4}) the Deno authors\\. All rights reserved\\. MIT license\\.\\n`,
+  "m",
 );
 const COPYRIGHT =
   `// Copyright 2023-${CURRENT_YEAR} the Deno authors. All rights reserved. MIT license.`;


### PR DESCRIPTION
Currently, when you add your own license to modified files, it will complain.

This changes the regex so that it can be multiline.