### PR TITLE
excluded dirs were included

### DIFF
--- a/tasks/check_license.ts
+++ b/tasks/check_license.ts
@@ -26,7 +26,7 @@ for await (
   const { path } of walk(ROOT, {
     exts: EXTENSIONS,
     skip: [
-      ...EXCLUDED_DIRS.map((path) => globToRegExp(path)),
+      ...EXCLUDED_DIRS.map((path) => globToRegExp(ROOT.pathname + path)),
       new RegExp("fresh.gen.ts"),
     ],
     includeDirs: false,


### PR DESCRIPTION
the walk function passes the absolute path, not the relative one