### PR TITLE
chore: remove `exclude` field from `deno.json`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -35,6 +35,5 @@
     "tabler_icons_tsx/": "https://deno.land/x/tabler_icons_tsx@0.0.4/tsx/",
     "fresh_charts/": "https://deno.land/x/fresh_charts@0.3.1/"
   },
-  "exclude": ["coverage/", "_fresh/", "**/_fresh/*"],
   "lint": { "rules": { "tags": ["fresh", "recommended"] } }
 }


### PR DESCRIPTION
This is not needed as excluding these folders from tools is taken care by defining them in `.gitignore`.