### PR TITLE
chore: remove `cov:gen` task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,8 @@ jobs:
       - name: Check formatting, linting, license headers, types and run tests
         run: deno task ok
 
-      - name: Create lcov file
-        run: deno task cov:gen
-
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:
           name: ${{ matrix.os }}
-          files: cov.lcov
+          files: coverage/lcov.info

--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,6 @@
     "check:license": "deno run --allow-read --allow-write tasks/check_license.ts",
     "check:types": "deno check main.ts && deno check dev.ts && deno check tasks/*.ts",
     "ok": "deno fmt --check && deno lint && deno task check:license --check && deno task check:types && deno task test",
-    "cov:gen": "deno coverage coverage --lcov --exclude='.tsx' --output=cov.lcov",
     "update": "deno run -A -r https://fresh.deno.dev/update .",
     "build": "deno run -A --unstable-kv dev.ts build",
     "preview": "deno run -A --unstable-kv main.ts"


### PR DESCRIPTION
This task is no longer needed as the `--coverage` flag in the `deno test` automatically produces the lcov file.